### PR TITLE
WS2-1627 - File blocking (with 403 errors) to hide files from security scans

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -11,3 +11,22 @@ protected_web_paths:
   - /private/
   - /sites/default/files/private/
   - /sites/default/files/config/
+  - /core/COPYRIGHT.txt
+  - /core/INSTALL.mysql.txt
+  - /core/INSTALL.pgsql.txt
+  - /core/INSTALL.sqlite.txt
+  - /core/INSTALL.txt
+  - /core/lib/README.txt
+  - /core/LICENSE.txt
+  - /core/MAINTAINERS.txt
+  - /core/PATCHES.txt
+  - /core/README.md
+  - /core/UPDATE.txt
+  - /core/USAGE.txt
+  - /core/lib/README.txt
+  - /core/tests/README.md
+  - /libraries/README.txt
+  - /modules/README.txt
+  - /profiles/README.txt
+  - /sites/README.txt
+  - /themes/README.txt


### PR DESCRIPTION
This change could've gone into ./pantheon.yml in the root of the repo (vs. pantheon.upstream.yml), but I wanted to avoid the possible conflicts with end users wanting to customize that file.