### PR TITLE
WS2-1662: Add missing class for install profile update.

### DIFF
--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -7,6 +7,7 @@
 
 use Drupal\user\Entity\User;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\pathauto\PathautoGeneratorInterface;
 
 /**
  * Implements hook_install().


### PR DESCRIPTION
### Description

When running database updates for 2.9.1 release, an error is thrown for the webspark profile install file due to a missing class declaration "PathautoGeneratorInterface".

Solution: Add the class to the top of the webspark.install file.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1662)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge
