### PR TITLE
WS2-1672 - local development helper: Allow select repo files to be easily blocked locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ upstream/web/
 # Ignore .env files as they are personal
 #/.env
 .DS_Store
+
+# Ignore local .gitignore changes with .git/info/exclude and a symbolic link via .gitignore_local
+.gitignore_local


### PR DESCRIPTION
### Description

Allow developers to block certain repo files locally by adding a .gitignore_local -> .git/info/exclude symbolic link.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1672)