### PR TITLE
WS2-1642: Card and Image – Parallax option on mobile is inconsistent

### DIFF
--- a/web/themes/webspark/renovation/src/components/cards/card-and-image-parallax.js
+++ b/web/themes/webspark/renovation/src/components/cards/card-and-image-parallax.js
@@ -4,7 +4,7 @@
   const scrollHandler = () => {
     document.querySelectorAll('.parallax-container').forEach((container) => {
       const the_image = container.querySelector('img');
-
+      the_image.style.minHeight = container.offsetHeight * MAGIC_PARALLAX_FACTOR + 'px';
       const default_position =
         container.offsetHeight - the_image.height * MAGIC_PARALLAX_FACTOR;
       const distance_to_travel =


### PR DESCRIPTION
### Description

In The Card and Image parallax option, on mobile, the image height is not consistent with other Card and Image options. Also, the parallax effect itself is inconsistent, as sometimes the starting position of the image is different. Finally, on mobile, the parallax shifts the content to the right and outside of the container.

Solution:  A minimum height was defined for the component image that matches the height of the parallax container.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1641)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

