### PR TITLE
WS2-1618: webspark_webdir: Depts listing people in the admin UI stacked, not in full alphabetical order

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b744988839bc4bfe0ea8a5cef461fe75",
+    "content-hash": "55ed8018e3e8e0feae2bcc590fa21822",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -67,7 +67,7 @@
             "version": "5.15.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "url": "git@github.com:FortAwesome/Font-Awesome.git",
                 "reference": "7d3d774145ac38663f6d1effc6def0334b68ab7e"
             },
             "dist": {
@@ -15029,6 +15029,60 @@
             "time": "2022-08-31T10:31:18+00:00"
         },
         {
+            "name": "sirbrillig/phpcs-changed",
+            "version": "v2.11.0-beta.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-changed.git",
+                "reference": "00c7070765eea7ac49e20d314f5a74030ab2ad56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/00c7070765eea7ac49e20d314f5a74030ab2ad56",
+                "reference": "00c7070765eea7ac49e20d314f5a74030ab2ad56",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "phpunit/phpunit": "^6.4 || ^9.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.1.3",
+                "squizlabs/php_codesniffer": "^3.2.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "bin": [
+                "bin/phpcs-changed"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpcsChanged/Cli.php",
+                    "PhpcsChanged/functions.php"
+                ],
+                "psr-4": {
+                    "PhpcsChanged\\": "PhpcsChanged/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.0-beta.2"
+            },
+            "time": "2023-06-06T13:57:02+00:00"
+        },
+        {
             "name": "sirbrillig/phpcs-variable-analysis",
             "version": "v2.11.16",
             "source": {
@@ -15850,5 +15904,5 @@
     "platform-overrides": {
         "php": "8.1.6"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/web/modules/webspark/webspark_webdir/js/list-field.js
+++ b/web/modules/webspark/webspark_webdir/js/list-field.js
@@ -33,7 +33,7 @@
             // Update the tree.
             update_tree(currentSize);
           });
-          
+
           // Hide "Web Directory customized sort" option by conditions.
           // @see https://asudev.jira.com/browse/ASUIS-574
           $(
@@ -104,7 +104,7 @@ function convert_asurite_to_tree(data, departments) {
 
           new_element.id = element.asurite_id.raw + ':' + deptid;
           // Remove maybe.
-          new_element.sort = element.last_name.raw;
+          new_element.sort = element.display_last_name.raw;
           new_element.text = element.display_name.raw + ', ' + element.asurite_id.raw +
                   ', ' + department_data['name']+ ', ' + title;
           new_element.type = "person";


### PR DESCRIPTION
### Description

<!-- Description of problem -->Forgot to change the sort to the new display_last_name prop
<!-- Solution -->
This fixes that problem.

To QA this, add "Office of the President" and "ASU Knowledge Enterprise > Biodesign Institute > Biodesign Center for Mechanisms of Evolution > Institute for Mechanism of Cellular Evolution > Leadership" as departments in the "Departments" component.

You will see that Kerry Geiler-Samerotte is now sorted correctly in the GUI listing.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1618)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<img width="756" alt="image" src="https://github.com/ASUWebPlatforms/webspark-ci/assets/6109406/b056a9ae-fe59-4b76-bf8f-87807786e98c">

Note: Sections that are not applicable for this issue can be removed.
