### PR TITLE
Ws2 1610: Web Directory People and People in Department listings Admin UI doesn't use pager for added profiles

### DIFF
--- a/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_component_type.yml
+++ b/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_component_type.yml
@@ -1,3 +1,4 @@
+uuid: 99968650-409a-4032-a07b-4321d84b2951
 langcode: en
 status: true
 dependencies:
@@ -6,12 +7,14 @@ dependencies:
     - field.storage.block_content.field_component_type
   module:
     - options
+_core:
+  default_config_hash: lEymzAjE9G4u-YMZI4dqvtPg0se-eJits5X9ceUqefo
 id: block_content.web_directory.field_component_type
 field_name: field_component_type
 entity_type: block_content
 bundle: web_directory
 label: 'Component type'
-description: ''
+description: "Note: For large department listings (over 99 profiles), we recommend using 'Departments' or 'Faculty by rank.'<br>\r\nThe other options are not intended or optimized for large data sets."
 required: true
 translatable: false
 default_value: {  }

--- a/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_component_type.yml
+++ b/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_component_type.yml
@@ -1,4 +1,3 @@
-uuid: 99968650-409a-4032-a07b-4321d84b2951
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
     - field.storage.block_content.field_component_type
   module:
     - options
-_core:
-  default_config_hash: lEymzAjE9G4u-YMZI4dqvtPg0se-eJits5X9ceUqefo
 id: block_content.web_directory.field_component_type
 field_name: field_component_type
 entity_type: block_content

--- a/web/modules/webspark/webspark_webdir/webspark_webdir.install
+++ b/web/modules/webspark/webspark_webdir/webspark_webdir.install
@@ -224,6 +224,13 @@ function webspark_webdir_update_9010(&$sandbox): void
 // }
 
 /**
+ * Update the component_type description.
+ */
+function webspark_webdir_update_9012(&$sandbox): void {
+  \Drupal::service('webspark.config_manager')->updateConfigFile('field.field.block_content.web_directory.field_component_type');
+}
+
+/**
  * Revert all the module's configs.
  */
 function _webspark_webdir_revert_all_module_config(): void


### PR DESCRIPTION
### Description

<!-- Description of problem -->
This PR adds help text describing how large departments shouldn't use "people" or "people in department", but rather use "departments" or "faculty by rank."
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1610)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->
<img width="669" alt="image" src="https://github.com/ASUWebPlatforms/webspark-ci/assets/6109406/86823c83-9460-4693-92c8-4d064c798e6f">

Note: Sections that are not applicable for this issue can be removed.
