### PR TITLE
correcting asu_brand dependency on renovation theme

### DIFF
--- a/web/themes/webspark/renovation/renovation.info.yml
+++ b/web/themes/webspark/renovation/renovation.info.yml
@@ -41,7 +41,7 @@ components:
     renovation: ./src/components
 
 dependencies:
-  - webspark/asu_brand
+  - asu_brand
 
 # Information added by Drupal.org packaging script on 2020-09-30
 version: '8.x-4.10'


### PR DESCRIPTION
### correction to dependency on renovation.info.yml

I added a new dependency to the renovation theme while working on [This ticket](https://asudev.jira.com/browse/WS2-1615)

This was incorrectly formatted which resulted in a missing dependency warning on the Drupal status page (see screenshots below)

<!-- Solution -->

I corrected the naming of the dependency, and confirm that error in UI is now resolved.

### Links

- [JIRA ticket bug was introduced on](https://asudev.jira.com/browse/WS2-1615)

### Verified in browsers 

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Error:
<img width="740" alt="Screenshot 2023-06-20 at 5 41 03 PM" src="https://github.com/ASUWebPlatforms/webspark-ci/assets/6909200/23966c5d-d41f-4664-b046-ddcc5e16f3c2">


Lack of error:
<img width="1313" alt="Screenshot 2023-06-20 at 5 39 49 PM" src="https://github.com/ASUWebPlatforms/webspark-ci/assets/6909200/9bbd8b6d-1021-4ef3-b6b8-e9fa1fd82ab5">


Note: Sections that are not applicable for this issue can be removed.
