### PR TITLE
WS2-1687 - Fix php warning about null values for react helper functions.

### DIFF
--- a/web/modules/webspark/asu_react_core/src/Utils/ReactComponentHelperFunctions.php
+++ b/web/modules/webspark/asu_react_core/src/Utils/ReactComponentHelperFunctions.php
@@ -117,23 +117,19 @@ class ReactComponentHelperFunctions {
     }
 
     // WS2-1674 - Card ranking image size 
-    if ($paragraph->field_card_ranking_image_size->value) {
+    if (isset($paragraph->field_card_ranking_image_size->value)) {
       if ($paragraph->field_card_ranking_image_size->value === 'small') {
         $card->imageSize = 'small';
-      } elseif ($paragraph->field_card_ranking_size->value === 'large') {
+        $card->citation = $paragraph->field_citation_title->value;
+      } elseif ($paragraph->field_card_ranking_image_size->value === 'large') {
         $card->imageSize = 'large';
       }
     }
     
     // WS2-1674 - Card ranking link URL, no link title
-    if ($paragraph->field_card_ranking_image_size->value && $paragraph->field_link->uri) {
+    if (isset($paragraph->field_card_ranking_image_size->value) && isset($paragraph->field_link->uri)) {
       $link = Url::fromUri($paragraph->field_link->uri);
       $card->linkUrl = $link->toString();
-    }
-
-    // WS2-1674 - Card ranking citation
-    if ($paragraph->field_card_ranking_image_size->value === 'small') {
-      $card->citation = $paragraph->field_citation_title->value;
     }
 
     //@TODO We are not going to send this information to the react component,
@@ -151,12 +147,18 @@ class ReactComponentHelperFunctions {
     if (isset($paragraph->field_icon)) {
       $icon_name = $paragraph->field_icon->icon_name;
       $icon_style = $paragraph->field_icon->style;
-      $icon_settings = unserialize($paragraph->field_icon->settings);
+      if (isset($paragraph->field_icon->settings)) {
+        // PHP 8.1 warning - when null is passed to build in function, 
+        // it is no longer silently converted to empty string
+        $icon_settings = unserialize($paragraph->field_icon->settings);
+      } else {
+        $icon_settings = '';
+      }
       $card->icon = [$icon_style, $icon_name, $icon_settings];
     }
 
     $card->clickable = false;
-    if ($paragraph->field_clickable->value && isset($paragraph->field_card_link->uri)){
+    if (isset($paragraph->field_clickable->value) && isset($paragraph->field_card_link->uri)){
       $card->clickable = true;
       $link = Url::fromUri($paragraph->field_card_link->uri);
       $card->clickHref = $link->toString();


### PR DESCRIPTION
### Description

There are php warnings for asu_react_core module helper functions that result from null values for ranking card, icon settings, and clickable props. Both icon settings and clickable have been removed for components, so we'll need to do some cleanup in the next release. Also, php 8.1 no longer lets null silently convert to an empty string so it needs to be checked then converted.

Solution: Add isset() checks for null.

### Links

- Related to [JIRA ticket](https://asudev.jira.com/browse/WS2-1687)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented in commit and on the Jira ticket
- [x] No new PHP or JS errors

Note: Sections that are not applicable for this issue can be removed.
