### PR TITLE
WS2-1557-A: Refactoring the logic to validate if Degree listing page exists

### DIFF
--- a/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
@@ -46,7 +46,9 @@ class AsuDegreePagesCreation extends ControllerBase {
     if (preg_match($pattern_url, $path)) {
       // Check if the Degree listing page exists.
       if (!isset($split_path[6]) || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == NULL) {
-        return ['#markup' => $this->t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]])];
+        $message = $this->t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]]);
+        \Drupal::logger('asu_degree_rfi')->warning($message);
+        return ['#markup' => $message];
       }
 
       $node = Node::create(['type' => 'degree_detail_page']);

--- a/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
@@ -43,12 +43,12 @@ class AsuDegreePagesCreation extends ControllerBase {
     $node_storage = \Drupal::service('entity_type.manager')->getStorage('node');
     $split_path = explode('/', $path);
 
-    // Check if the Degree listing page exists.
-    if ($split_path[6] == NULL || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == NULL) {
-      return new Response(t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]]), 404);
-    }
-
     if (preg_match($pattern_url, $path)) {
+      // Check if the Degree listing page exists.
+      if (!isset($split_path[6]) || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == NULL) {
+        return ['#markup' => $this->t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]])];
+      }
+
       $node = Node::create(['type' => 'degree_detail_page']);
       $degree_query = $this->degreeSearchClient->getDegreeByAcadPlan($split_path[3]);
       $title = isset($degree_query[0]['Descr100']) ? $degree_query[0]['Descr100'] : $split_path[3];

--- a/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeDetailsBlock.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeDetailsBlock.php
@@ -121,7 +121,7 @@ class AsuDegreeRfiDegreeDetailsBlock extends BlockBase {
       if (isset($split[6]) && is_numeric($split[6])) {
         $node_storage = \Drupal::entityTypeManager()->getStorage('node');
         $listing_page_node = $node_storage->load($split[6]);
-        if ($node) {
+        if ($node && $listing_page_node) {
           $breadcrumbs[] = (object) [
             'text' => $listing_page_node->getTitle(),
             'url' => Url::fromRoute('entity.node.canonical', ['node' => $listing_page_node->id()])->toString(),

--- a/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
@@ -241,7 +241,7 @@ class AsuDegreeRfiDegreeListingBlock extends BlockBase {
     }
 
     if ($node->field_degree_degrees_per_page->value) {
-      $props['degreesPerPage'] = $node->field_degree_degrees_per_page->value;
+      $props['degreesPerPage'] = (int){$node->field_degree_degrees_per_page->value};
     }
     $props['programList'] = $programList;
 

--- a/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
@@ -241,7 +241,7 @@ class AsuDegreeRfiDegreeListingBlock extends BlockBase {
     }
 
     if ($node->field_degree_degrees_per_page->value) {
-      $props['degreesPerPage'] = (int){$node->field_degree_degrees_per_page->value};
+      $props['degreesPerPage'] = (int)$node->field_degree_degrees_per_page->value;
     }
     $props['programList'] = $programList;
 


### PR DESCRIPTION
### Description
_From Michael :_ 
"We need logic in https://github.com/ASUWebPlatforms/webspark-ci/blob/master/web/modules/webspark/asu_degree_rfi/src/Routing/RouteSubscriber.php or
https://github.com/ASUWebPlatforms/webspark-ci/blob/master/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php so that the “The Degree listing page with nid: could not be found” message only displays when the path matches known degree listing page patterns, otherwise, we should display the WS2 404 page (which looks, as an example, like this: https://search.asu.edu/ljlkjlkjlkj)."

**Solution** : Logic was moved some lines below, so regex first evaluate if the URL is correct, then I validate if it belongs to a degree listing page node.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1557)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
