### PR TITLE
WS2-1704a - Add blocks revert function before update 9017.

### DIFF
--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -51,6 +51,13 @@ function webspark_blocks_update_9005(&$sandbox) {
 }
 
 /**
+ * WS2-1704 - Add back blocks revert call
+ */
+function webspark_blocks_update_9012(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Update 'Show borders' field on cards paragraphs to ensure it has a default value.
  */
 function webspark_blocks_update_9017() {


### PR DESCRIPTION
### Description

Multiple revert function calls were removed before update 9017, one of which (9012) created the field_show_borders field, so if a site hasn't been updated in a while (2.7) it will hang on update 9017.

Solution: Add back _webspark_blocks_revert_module_config(); before update 9017

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1704)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors