### PR TITLE
WS2-1737: Fix config update functionality in webspark_utility module

### DIFF
--- a/web/modules/webspark/webspark_utility/webspark_utility.services.yml
+++ b/web/modules/webspark/webspark_utility/webspark_utility.services.yml
@@ -1,4 +1,4 @@
 services:
   webspark.config_manager:
     class: Drupal\webspark_utility\WebsparkUtilityConfigManager
-    arguments: ['@entity_type.manager', '@config.storage', '@config_update.extension_storage', '@config_update.config_update', '@module_handler']
+    arguments: ['@entity_type.manager', '@config.storage', '@config_update.extension_storage', '@config_update.config_update', '@module_handler', '@config.factory']


### PR DESCRIPTION
### Description

People are having a hard time updating to WS2 2.10.2 because of the webspark_update_9014. I discovered that the problem here is that the update_config function being used assumes that the config is already in the active configs. However, this may not always be the case.

So, I have added a check to see if it exists in the active configs, and if not, it installs the config instead of updates it.

This solves the problem.
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1737)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

Note: Sections that are not applicable for this issue can be removed.
