### PR TITLE
Ws2 1578

### DIFF
--- a/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
+++ b/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
@@ -103,7 +103,7 @@
     <div class="container" id="footer-columns">
       <div class="row">
         <div class="col-xl" id="info-column">
-          <h5>{{ unit_name }}</h5>
+          <p class="h5">{{ unit_name }}</p>
           {% if link_url and link_title %}
             <p class="contact-link">
             <a
@@ -130,7 +130,7 @@
           <div class="card accordion-item desktop-disable-xl">
           {% for c in column %}
             <div class="accordion-header">
-              <h5>
+              <p class="h5">
                 <a
                   id="footlink-header-{{ key }}-{{ loop.index }}"
                   class="collapsed"
@@ -148,7 +148,7 @@
                   {{ c.title }}
                   <span class="fas fa-chevron-up"></span>
                 </a>
-              </h5>
+              </p>
             </div>
             <div
               id="footlink-{{ key }}-{{ loop.index }}"

--- a/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
+++ b/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
@@ -103,7 +103,7 @@
     <div class="container" id="footer-columns">
       <div class="row">
         <div class="col-xl" id="info-column">
-          <p class="h5">{{ unit_name }}</p>
+          <div class="h5">{{ unit_name }}</div>
           {% if link_url and link_title %}
             <p class="contact-link">
             <a
@@ -130,7 +130,7 @@
           <div class="card accordion-item desktop-disable-xl">
           {% for c in column %}
             <div class="accordion-header">
-              <p class="h5">
+              <div class="h5">
                 <a
                   id="footlink-header-{{ key }}-{{ loop.index }}"
                   class="collapsed"
@@ -148,7 +148,7 @@
                   {{ c.title }}
                   <span class="fas fa-chevron-up"></span>
                 </a>
-              </p>
+              </div>
             </div>
             <div
               id="footlink-{{ key }}-{{ loop.index }}"


### PR DESCRIPTION
### Description

### Description of problem
H5 headings in the footer cause accessibility issues when heading levels are skipped.  

### Solution
Change H5 headings in the footer into DIVs with class=h5 to avoid headings being skipped. The h5 class retains all the same styles of the h5 tag. (don't use P tags b/c of max-width)

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1578)

### Checklist

- [X] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [X] Solution is documented on the Jira ticket
- [X] QA steps to verify have been included on the Jira ticket
- [X] No new PHP or JS errors
- [X] No accessibility issues are introduced with this update


