### PR TITLE
WS2 1688 - configure cropping image styles to crop aspect ratio by default

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
+_core:
+  default_config_hash: N9Lp5_JUcAmX9LZ7Z3lgguP_sezJntBe5y6naDaaACw
 name: block_image_16_9_lge
 label: 'Block Image 16:9 LGE'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  176d45d2-41a1-47d5-92f8-6f92eeaf7f7f:
-    uuid: 176d45d2-41a1-47d5-92f8-6f92eeaf7f7f
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 1200
-      height: null
-      upscale: false
+      height: 675
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: N9Lp5_JUcAmX9LZ7Z3lgguP_sezJntBe5y6naDaaACw
 name: block_image_16_9_lge
 label: 'Block Image 16:9 LGE'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  176d45d2-41a1-47d5-92f8-6f92eeaf7f7f:
+    uuid: 176d45d2-41a1-47d5-92f8-6f92eeaf7f7f
+    id: image_scale
     weight: 2
     data:
       width: 1200
-      height: 675
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: N9Lp5_JUcAmX9LZ7Z3lgguP_sezJntBe5y6naDaaACw
 name: block_image_16_9_lge
 label: 'Block Image 16:9 LGE'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: aDjcCPLVYd5pHz222uIsfk-BdArIvONknboXb_Ut6l4
 name: block_image_16_9_med
 label: 'Block Image 16:9 MED'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  9189f0ad-656f-4ea0-9914-3a7252b0f900:
+    uuid: 9189f0ad-656f-4ea0-9914-3a7252b0f900
+    id: image_scale
     weight: 2
     data:
       width: 600
-      height: 337
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: aDjcCPLVYd5pHz222uIsfk-BdArIvONknboXb_Ut6l4
 name: block_image_16_9_med
 label: 'Block Image 16:9 MED'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
+_core:
+  default_config_hash: aDjcCPLVYd5pHz222uIsfk-BdArIvONknboXb_Ut6l4
 name: block_image_16_9_med
 label: 'Block Image 16:9 MED'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  9189f0ad-656f-4ea0-9914-3a7252b0f900:
-    uuid: 9189f0ad-656f-4ea0-9914-3a7252b0f900
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 600
-      height: null
-      upscale: false
+      height: 337
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
+_core:
+  default_config_hash: 52PalyXnG0m6vyNyfJ6CL2C1FQ2IyRIaqWxkqpK1ZOw
 name: block_image_16_9_sml
 label: 'Block Image 16:9 SML'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  850e3332-df80-4773-bdc4-4ef08495d250:
-    uuid: 850e3332-df80-4773-bdc4-4ef08495d250
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 300
-      height: null
-      upscale: false
+      height: 168
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: 52PalyXnG0m6vyNyfJ6CL2C1FQ2IyRIaqWxkqpK1ZOw
 name: block_image_16_9_sml
 label: 'Block Image 16:9 SML'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.16_9
   module:
     - crop
-_core:
-  default_config_hash: 52PalyXnG0m6vyNyfJ6CL2C1FQ2IyRIaqWxkqpK1ZOw
 name: block_image_16_9_sml
 label: 'Block Image 16:9 SML'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '16_9'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  850e3332-df80-4773-bdc4-4ef08495d250:
+    uuid: 850e3332-df80-4773-bdc4-4ef08495d250
+    id: image_scale
     weight: 2
     data:
       width: 300
-      height: 168
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: cDdAVcR1eheRnACjLlHTgMgnkoB3Oxe18R_S2FEHjj0
 name: block_image_1_1_lge
 label: 'Block Image 1:1 LGE'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
+_core:
+  default_config_hash: cDdAVcR1eheRnACjLlHTgMgnkoB3Oxe18R_S2FEHjj0
 name: block_image_1_1_lge
 label: 'Block Image 1:1 LGE'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  f99e0dde-2884-4351-8da9-8ba18fd4cb6f:
-    uuid: f99e0dde-2884-4351-8da9-8ba18fd4cb6f
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 1200
-      height: null
-      upscale: false
+      height: 1200
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: cDdAVcR1eheRnACjLlHTgMgnkoB3Oxe18R_S2FEHjj0
 name: block_image_1_1_lge
 label: 'Block Image 1:1 LGE'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  f99e0dde-2884-4351-8da9-8ba18fd4cb6f:
+    uuid: f99e0dde-2884-4351-8da9-8ba18fd4cb6f
+    id: image_scale
     weight: 2
     data:
       width: 1200
-      height: 1200
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
+_core:
+  default_config_hash: T2gWCN5TM7nlDz4h3wTwLi1J8TKPPBIZUsiE0WKMO18
 name: block_image_1_1_med
 label: 'Block Image 1:1 MED'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  640ddcdf-01f3-4dec-b0e0-40a319fb70a7:
-    uuid: 640ddcdf-01f3-4dec-b0e0-40a319fb70a7
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 600
-      height: null
-      upscale: false
+      height: 600
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: T2gWCN5TM7nlDz4h3wTwLi1J8TKPPBIZUsiE0WKMO18
 name: block_image_1_1_med
 label: 'Block Image 1:1 MED'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  640ddcdf-01f3-4dec-b0e0-40a319fb70a7:
+    uuid: 640ddcdf-01f3-4dec-b0e0-40a319fb70a7
+    id: image_scale
     weight: 2
     data:
       width: 600
-      height: 600
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: T2gWCN5TM7nlDz4h3wTwLi1J8TKPPBIZUsiE0WKMO18
 name: block_image_1_1_med
 label: 'Block Image 1:1 MED'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: 6bdZIwtgehRw2-DWrcNnLlpysBotWzkzRpsIHnCKvrM
 name: block_image_1_1_sml
 label: 'Block Image 1:1 SML'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
+  dcca3cee-9b08-4dd1-ac36-830fed719a2b:
+    uuid: dcca3cee-9b08-4dd1-ac36-830fed719a2b
+    id: image_scale
     weight: 2
     data:
       width: 300
-      height: 300
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
+_core:
+  default_config_hash: 6bdZIwtgehRw2-DWrcNnLlpysBotWzkzRpsIHnCKvrM
 name: block_image_1_1_sml
 label: 'Block Image 1:1 SML'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: '1_1'
       automatic_crop_provider: null
-  dcca3cee-9b08-4dd1-ac36-830fed719a2b:
-    uuid: dcca3cee-9b08-4dd1-ac36-830fed719a2b
-    id: image_scale
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
     weight: 2
     data:
       width: 300
-      height: null
-      upscale: false
+      height: 300
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.1_1
   module:
     - crop
-_core:
-  default_config_hash: 6bdZIwtgehRw2-DWrcNnLlpysBotWzkzRpsIHnCKvrM
 name: block_image_1_1_sml
 label: 'Block Image 1:1 SML'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: jRIAaKjkjbBaY_hiAoDxrlzluMnjGPmWmbFSBk6jgI0
 name: block_image_lge
 label: 'Block Image 4:3 LGE'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
@@ -5,23 +5,21 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: jRIAaKjkjbBaY_hiAoDxrlzluMnjGPmWmbFSBk6jgI0
 name: block_image_lge
 label: 'Block Image 4:3 LGE'
 effects:
+  e71d3617-e0aa-46cb-bcfc-3f5a06a21fc6:
+    uuid: e71d3617-e0aa-46cb-bcfc-3f5a06a21fc6
+    id: image_scale
+    weight: -9
+    data:
+      width: 1200
+      height: null
+      upscale: true
   84e86f53-c681-43db-bab9-96ca933f1e43:
     uuid: 84e86f53-c681-43db-bab9-96ca933f1e43
     id: crop_crop
-    weight: 1
+    weight: -10
     data:
       crop_type: images_block
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
-    weight: 2
-    data:
-      width: 1200
-      height: 900
-      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
@@ -5,21 +5,23 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
+_core:
+  default_config_hash: jRIAaKjkjbBaY_hiAoDxrlzluMnjGPmWmbFSBk6jgI0
 name: block_image_lge
 label: 'Block Image 4:3 LGE'
 effects:
-  e71d3617-e0aa-46cb-bcfc-3f5a06a21fc6:
-    uuid: e71d3617-e0aa-46cb-bcfc-3f5a06a21fc6
-    id: image_scale
-    weight: -9
-    data:
-      width: 1200
-      height: null
-      upscale: true
   84e86f53-c681-43db-bab9-96ca933f1e43:
     uuid: 84e86f53-c681-43db-bab9-96ca933f1e43
     id: crop_crop
-    weight: -10
+    weight: 1
     data:
       crop_type: images_block
       automatic_crop_provider: null
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 1200
+      height: 900
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: wbXksEugCDokft1KXOlV8FBuWEKTEVncYeZ8RSvaF8M
 name: block_image_med
 label: 'Block Image 4:3 MED'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
@@ -5,23 +5,21 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: wbXksEugCDokft1KXOlV8FBuWEKTEVncYeZ8RSvaF8M
 name: block_image_med
 label: 'Block Image 4:3 MED'
 effects:
+  bf180d68-8396-414f-940a-054d3303936f:
+    uuid: bf180d68-8396-414f-940a-054d3303936f
+    id: image_scale
+    weight: -9
+    data:
+      width: 600
+      height: null
+      upscale: false
   0a882e9e-e146-4547-a484-49afc6b66d30:
     uuid: 0a882e9e-e146-4547-a484-49afc6b66d30
     id: crop_crop
-    weight: 1
+    weight: -10
     data:
       crop_type: images_block
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
-    weight: 2
-    data:
-      width: 600
-      height: 450
-      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
@@ -5,21 +5,23 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
+_core:
+  default_config_hash: wbXksEugCDokft1KXOlV8FBuWEKTEVncYeZ8RSvaF8M
 name: block_image_med
 label: 'Block Image 4:3 MED'
 effects:
-  bf180d68-8396-414f-940a-054d3303936f:
-    uuid: bf180d68-8396-414f-940a-054d3303936f
-    id: image_scale
-    weight: -9
-    data:
-      width: 600
-      height: null
-      upscale: false
   0a882e9e-e146-4547-a484-49afc6b66d30:
     uuid: 0a882e9e-e146-4547-a484-49afc6b66d30
     id: crop_crop
-    weight: -10
+    weight: 1
     data:
       crop_type: images_block
       automatic_crop_provider: null
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 600
+      height: 450
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: s5gSpvG770qeE17cO1--5I1uBi8QObO4Ol0QwThk310
 name: block_image_sml
 label: 'Block Image 4:3 SML'
 effects:

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
@@ -5,23 +5,21 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
-_core:
-  default_config_hash: s5gSpvG770qeE17cO1--5I1uBi8QObO4Ol0QwThk310
 name: block_image_sml
 label: 'Block Image 4:3 SML'
 effects:
+  00e129fe-b2a9-41eb-804c-acb607d5ca0d:
+    uuid: 00e129fe-b2a9-41eb-804c-acb607d5ca0d
+    id: image_scale
+    weight: -9
+    data:
+      width: 300
+      height: null
+      upscale: false
   0024e38e-1e1a-4a93-a883-254255d0257f:
     uuid: 0024e38e-1e1a-4a93-a883-254255d0257f
     id: crop_crop
-    weight: 1
+    weight: -10
     data:
       crop_type: images_block
       automatic_crop_provider: null
-  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
-    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
-    id: image_scale_and_crop
-    weight: 2
-    data:
-      width: 300
-      height: 225
-      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
@@ -5,21 +5,23 @@ dependencies:
     - crop.type.images_block
   module:
     - crop
+_core:
+  default_config_hash: s5gSpvG770qeE17cO1--5I1uBi8QObO4Ol0QwThk310
 name: block_image_sml
 label: 'Block Image 4:3 SML'
 effects:
-  00e129fe-b2a9-41eb-804c-acb607d5ca0d:
-    uuid: 00e129fe-b2a9-41eb-804c-acb607d5ca0d
-    id: image_scale
-    weight: -9
-    data:
-      width: 300
-      height: null
-      upscale: false
   0024e38e-1e1a-4a93-a883-254255d0257f:
     uuid: 0024e38e-1e1a-4a93-a883-254255d0257f
     id: crop_crop
-    weight: -10
+    weight: 1
     data:
       crop_type: images_block
       automatic_crop_provider: null
+  869ce27f-f47e-42ed-87b4-5f4c4181e47d:
+    uuid: 869ce27f-f47e-42ed-87b4-5f4c4181e47d
+    id: image_scale_and_crop
+    weight: 2
+    data:
+      width: 300
+      height: 225
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
@@ -5,6 +5,8 @@ dependencies:
     - crop.type.mobile_video_poster
   module:
     - crop
+_core:
+  default_config_hash: FfwhPYY1L14WOZtREUy7tAuRfSCTba1X3xczTbj93I4
 name: video_poster_image
 label: 'Video Poster Image'
 effects:
@@ -15,11 +17,11 @@ effects:
     data:
       crop_type: mobile_video_poster
       automatic_crop_provider: null
-  675ebd1f-0b5c-4040-8b98-11268d137f67:
-    uuid: 675ebd1f-0b5c-4040-8b98-11268d137f67
-    id: image_scale
-    weight: 2
+  ee5e36ac-f211-4a32-8161-20671aac2c6d:
+    uuid: ee5e36ac-f211-4a32-8161-20671aac2c6d
+    id: image_scale_and_crop
+    weight: 3
     data:
       width: 375
-      height: null
-      upscale: false
+      height: 513
+      anchor: center-center

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.mobile_video_poster
   module:
     - crop
-_core:
-  default_config_hash: FfwhPYY1L14WOZtREUy7tAuRfSCTba1X3xczTbj93I4
 name: video_poster_image
 label: 'Video Poster Image'
 effects:
@@ -17,11 +15,11 @@ effects:
     data:
       crop_type: mobile_video_poster
       automatic_crop_provider: null
-  ee5e36ac-f211-4a32-8161-20671aac2c6d:
-    uuid: ee5e36ac-f211-4a32-8161-20671aac2c6d
-    id: image_scale_and_crop
-    weight: 3
+  675ebd1f-0b5c-4040-8b98-11268d137f67:
+    uuid: 675ebd1f-0b5c-4040-8b98-11268d137f67
+    id: image_scale
+    weight: 2
     data:
       width: 375
-      height: 513
-      anchor: center-center
+      height: null
+      upscale: false

--- a/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
@@ -5,8 +5,6 @@ dependencies:
     - crop.type.mobile_video_poster
   module:
     - crop
-_core:
-  default_config_hash: FfwhPYY1L14WOZtREUy7tAuRfSCTba1X3xczTbj93I4
 name: video_poster_image
 label: 'Video Poster Image'
 effects:

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -157,21 +157,3 @@ function _webspark_blocks_revert_module_config() {
   // Lock the configuration storage.
   \Drupal::state()->set('configuration_locked', TRUE);
 }
-
-/**
- * update cropping image styles
- */
-function webspark_blocks_update_9021(&$sandbox) {
-  \Drupal::state()->set('configuration_locked', FALSE);
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_lge');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_med');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_sml');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_lge');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_med');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_sml');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_lge');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_med');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_sml');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.video_poster_image');
-  \Drupal::state()->set('configuration_locked', TRUE);
-}

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -157,3 +157,21 @@ function _webspark_blocks_revert_module_config() {
   // Lock the configuration storage.
   \Drupal::state()->set('configuration_locked', TRUE);
 }
+
+/**
+ * update cropping image styles
+ */
+function webspark_blocks_update_9021(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_lge');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_med');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_1_1_sml');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_lge');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_med');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_16_9_sml');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_lge');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_med');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.block_image_sml');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('image.style.video_poster_image');
+  \Drupal::state()->set('configuration_locked', TRUE);
+}


### PR DESCRIPTION
### Description

**Issue:** It’s not obvious to user that crop bounding box must be clicked on in order to apply cropping, and can be saved regardless.

**Solution:** Reconfigure image styles that include the cropping tool so that they “Scale and crop” to a specific aspect ratio if the cropper is not clicked on before saving.

modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_lge.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_med.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_16_9_sml.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_lge.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_med.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_1_1_sml.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_lge.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_med.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.block_image_sml.yml
modified:   web/modules/webspark/webspark_blocks/config/install/image.style.video_poster_image.yml
modified:   web/modules/webspark/webspark_blocks/webspark_blocks.install


- Recommend link back to original Media item from component configuration modal window so user can update cropping if the default cropping was applied and not to their liking (I'll create a new ticket)

- Note for service team: If client’s Drupal site uses a subtheme of renovation, in other words, a sub-sub-theme, then /image/image--crop-thumbnail.html.twig must be copied from renovation to the sub-sub-theme folder in order for the blue crop lines to appear on the cropping tool.


### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1688)

### Checklist

- [X] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [X] Solution is documented on the Jira ticket
- [X] QA steps to verify have been included on the Jira ticket
- [X] No new PHP or JS errors
- [X] No accessibility issues are introduced with this update

### Verified in browsers 

- [X] Chrome
- [X] Safari
- [X] Firefox
- [x] Edge


