### PR TITLE
ws2-1754 - bypass validation setting in fontawesome.settings.yml

### DIFF
--- a/web/profiles/webspark/webspark/config/install/fontawesome.settings.yml
+++ b/web/profiles/webspark/webspark/config/install/fontawesome.settings.yml
@@ -13,7 +13,7 @@ use_brands_file: true
 use_duotone_file: false
 use_thin_file: false
 external_svg_integrity: ''
-bypass_validation: false
+bypass_validation: true
 use_sharpregular_file: false
 use_sharplight_file: false
 use_sharpsolid_file: false


### PR DESCRIPTION
Bypass FontAwesome validation to avoid false positive validation failures. Needed for how we've decoupled from FA module with rendering.

Test:
On https://pr-148-webspark-ci.ws.asu.edu/card-arrangement attempt replacing the broken card icon with one of the pictoral numeric icons from the first page of options in the icon picker widget. Shouldn't throw an error.
Also view `/admin/config/content/fontawesome` and verify that the bypass validation is checked.