### PR TITLE
ws2-1754 don't to alow configure regular file icons in widget

### DIFF
--- a/web/profiles/webspark/webspark/config/install/fontawesome.settings.yml
+++ b/web/profiles/webspark/webspark/config/install/fontawesome.settings.yml
@@ -7,7 +7,7 @@ use_shim: true
 external_shim_location: ''
 allow_pseudo_elements: false
 use_solid_file: true
-use_regular_file: true
+use_regular_file: false
 use_light_file: false
 use_brands_file: true
 use_duotone_file: false


### PR DESCRIPTION
"regular" non-solid icons account for empty spaces in the picker. We don't load the non-solid icons, so shouldn't have them enabled in the picker. Most are pro-only, and those don't appear in the picker, but enough aren't pro and they try to render but don't. This update prevents them from rendering as blanks in the picker.