### PR TITLE
WS2-1786 check for not empty to avoid false positives

### DIFF
--- a/web/modules/webspark/asu_brand/src/AsuBrandHelperFunctions.php
+++ b/web/modules/webspark/asu_brand/src/AsuBrandHelperFunctions.php
@@ -15,8 +15,8 @@ class AsuBrandHelperFunctions {
     $search_config = \Drupal::config('asu_brand.settings');
     $asu_search_url = $search_config->get('asu_brand.asu_brand_search_url') ?? '';
     // Domain-specific results host
-    $local_search_url = $search_config->get('asu_brand.asu_brand_local_search_url') ?? \Drupal::request()->getHost();
-    // "opt-out"
+    $local_search_url = !empty($search_config->get('asu_brand.asu_brand_local_search_url')) ? $search_config->get('asu_brand.asu_brand_local_search_url') : \Drupal::request()->getHost();
+    // Check for "opt-out" override.
     $url_host = ($local_search_url === 'opt-out') ? '' : $local_search_url;
     return ['asu_search_url' => $asu_search_url, 'url_host' => $url_host];
   }


### PR DESCRIPTION
### Description

Empty local search values, after code refactor in brand module, broke the "empty" value fallback to the site's domain. This resulted in local search settings defaulting to an empty string.

This PR corrects that by checking for !empty instead.

Test
* At `/admin/config/asu_brand/settings` try various "Local Search URL" settings.
* After changing, clear the cache.
* Perform a search from the header. The domain you configured should show as the local search results on https://search.asu.edu.  If you leave the field blank, the current site's domain should be used.

The local search parameter can be verified by looking at the original site's search form (`url_host` is a hidden field and should match the configuration or default fallback). You can also verify after a search by checking for the `url_host` in the path, and for the existence of the domain as a tab above the search results.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1786)