### PR TITLE
Update Webspark profile version number to 2.11.0

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -76,5 +76,5 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.11"
+    "version": "2.11.0"
 }

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -2,7 +2,7 @@ name: Webspark
 type: profile
 core_version_requirement: ^9.0
 description: 'ASU custom profile.'
-version: 2.10.2
+version: 2.11.0
 distribution:
   name: 'Webspark'
 install:


### PR DESCRIPTION
Update the WS2 installation profile to 2.11.0.