### PR TITLE
Ws2 1797

### DIFF
--- a/web/themes/webspark/renovation/src/components/heroes/image-hero.twig
+++ b/web/themes/webspark/renovation/src/components/heroes/image-hero.twig
@@ -1,4 +1,4 @@
-<div class="uds-hero-{{ size }} {{ size == 'lg' ? 'hide-content' }} {{ has_button_row ? 'has-btn-row' }}">
+<div class="uds-hero-{{ size }} {{ has_button_row ? 'has-btn-row' }}">
   <div class="hero-overlay"></div>
 
   <img class="hero" src="{{ hero_background }}" alt="{{ hero_alt }}" loading="lazy" decoding="async" fetchpriority="high"/>


### PR DESCRIPTION
### Description

### Description of problem:
Content is being hidden for the large hero on mobile breakpoints when it should remain visible

### Solution:
Remove `{{ size == 'lg' ? 'hide-content' }}` from line 1 of` image-hero.twig` template


### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1797)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

### Before:
![image](https://github.com/ASUWebPlatforms/webspark-ci/assets/7406481/f1c2a15a-7574-4839-baa3-c68de5fdff7d)


### After:
![image](https://github.com/ASUWebPlatforms/webspark-ci/assets/7406481/c3878c41-c04e-4e8e-921b-10b41e082982)

