### PR TITLE
WS2-1807: Remove extra closing head tag

### DIFF
--- a/web/themes/webspark/renovation/templates/system/html.html.twig
+++ b/web/themes/webspark/renovation/templates/system/html.html.twig
@@ -32,11 +32,10 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
-      {# Load FontAwesome 6 free icons. Also, load ASU Awesome.
-    Loading it this way resolves clashes that previously occurred with ASU Awesome. #}
-      <script defer src="/libraries/fontawesome/js/all.min.js"></script>
-      <script defer src="/themes/webspark/renovation/js/asuawesome.js"></script>
-  </head>
+    {# Load FontAwesome 6 free icons. Also, load ASU Awesome. #}
+    {# Loading it this way resolves clashes that previously occurred with ASU Awesome. #}
+    <script defer src="/libraries/fontawesome/js/all.min.js"></script>
+    <script defer src="/themes/webspark/renovation/js/asuawesome.js"></script>
   </head>
   <body{{attributes}}>
     {% if logged_in and user.hasPermission('Use the toolbar') %}
@@ -50,4 +49,3 @@
     <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>
-


### PR DESCRIPTION
### Description

After the BS5 migration, there is an extra closing tag for the `<head>`. This PR removes that extra closing tag.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1807)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
