### PR TITLE
WS2-1808: Fix horizontal scroll for full width layouts

### DIFF
--- a/web/modules/webspark/webspark_module_renovation_layouts/README.md
+++ b/web/modules/webspark/webspark_module_renovation_layouts/README.md
@@ -6,13 +6,15 @@ Provides a switchable layout for renovation theme.
 
 ## Details
 
-  Provides the following sections:
+Provides the following sections:
+
 - One column fixed width
 - One column full width
 - Two, three and four col fixed width
 
-  The fixed width is represented by the "containter" class in the bootstrap.
-  The full width stretches to the entire width of the page. 
+> NOTE: Containers are required when using the [Bootstrap grid system](https://getbootstrap.com/docs/5.3/layout/containers) **except** in the case you want an edge to edge layout. There, is is okay to omit the container class, but you must [apply classes to remove the margin or gutter](https://getbootstrap.com/docs/5.3/layout/gutters/#no-gutters).
+
+The fixed width is represented by the "containter" class in the bootstrap. The full width stretches to the entire width of the page.
 
 ## Requirements
 
@@ -20,5 +22,4 @@ Drupal 8.x. or Drupal 9.x
 
 ## How to use
 
-  In the layout builder "+ Add Section" all the options will be provided
-including these ones.
+In the layout builder "+ Add Section" all the options will be provided including these ones.

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
@@ -1,5 +1,5 @@
 {% if content %}
-  <div class="row no-gutters">
+  <div class="row g-0">
     <div class="col uds-full-width">
       <div{{ attributes.addClass('layout__full-width') }}>
         {% if content.first %}


### PR DESCRIPTION
### Description

Since the BS5 upgrade, full width content layouts that contain content now have a horizontal scroll.

### Solution

The `no-gutters` class was removed from BS5 and replaced with `g-0`. This PR applies that change.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1808)

### QA Steps

- Review any page on the website that uses a full width layout. Common pages would be ones using Heroes.
- Ensure your monitor is using a screen resolution of 1920x1080. Using a resolution higher than this will make it hard to see the issue or not.
- Ensure the page does not scroll horizontally.
- Inspect the source code for something using a full width container, and ensure the code is using the `g-0` class instead of `no-gutters`.

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge
