### PR TITLE
WS2-1835 remove old fields form core.entity_* ymls in webspark_webdir

### DIFF
--- a/web/modules/webspark/webspark_webdir/config/install/core.entity_form_display.block_content.web_directory.default.yml
+++ b/web/modules/webspark/webspark_webdir/config/install/core.entity_form_display.block_content.web_directory.default.yml
@@ -11,13 +11,10 @@ dependencies:
     - field.field.block_content.web_directory.field_filter_employee
     - field.field.block_content.web_directory.field_filter_expertise
     - field.field.block_content.web_directory.field_filter_title
-    - field.field.block_content.web_directory.field_ids
-    - field.field.block_content.web_directory.field_news_items_to_display
     - field.field.block_content.web_directory.field_people_add
     - field.field.block_content.web_directory.field_people_add_department
     - field.field.block_content.web_directory.field_people_list
     - field.field.block_content.web_directory.field_people_search
-    - field.field.block_content.web_directory.field_show_title
     - field.field.block_content.web_directory.field_webdir_exclude_profiles
     - field.field.block_content.web_directory.field_webdir_items_to_display
     - field.field.block_content.web_directory.field_webdir_use_pager
@@ -31,11 +28,8 @@ third_party_settings:
     group_display_settings:
       children:
         - field_default_sort
-        - field_show_title
         - field_webdir_use_pager
-        - field_news_items_to_display
         - field_webdir_items_to_display
-        - field_ids
         - field_webdir_exclude_profiles
         - field_webdir_disable_alpha
       label: 'Display settings'
@@ -327,21 +321,6 @@ content:
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
         maxlength_js_truncate_html: false
-  field_ids:
-    type: string_textfield
-    weight: 21
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_news_items_to_display:
-    type: number
-    weight: 19
-    region: content
-    settings:
-      placeholder: ''
-    third_party_settings: {  }
   field_people_add:
     type: field_webdir_add_widget
     weight: 10
@@ -440,13 +419,6 @@ content:
       maxlength:
         maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-  field_show_title:
-    type: boolean_checkbox
-    weight: 17
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   field_webdir_exclude_profiles:
     type: string_textfield
     weight: 22

--- a/web/modules/webspark/webspark_webdir/config/install/core.entity_view_display.block_content.web_directory.default.yml
+++ b/web/modules/webspark/webspark_webdir/config/install/core.entity_view_display.block_content.web_directory.default.yml
@@ -11,13 +11,10 @@ dependencies:
     - field.field.block_content.web_directory.field_filter_employee
     - field.field.block_content.web_directory.field_filter_expertise
     - field.field.block_content.web_directory.field_filter_title
-    - field.field.block_content.web_directory.field_ids
-    - field.field.block_content.web_directory.field_news_items_to_display
     - field.field.block_content.web_directory.field_people_add
     - field.field.block_content.web_directory.field_people_add_department
     - field.field.block_content.web_directory.field_people_list
     - field.field.block_content.web_directory.field_people_search
-    - field.field.block_content.web_directory.field_show_title
     - field.field.block_content.web_directory.field_webdir_exclude_profiles
     - field.field.block_content.web_directory.field_webdir_items_to_display
     - field.field.block_content.web_directory.field_webdir_use_pager
@@ -36,13 +33,10 @@ hidden:
   field_filter_employee: true
   field_filter_expertise: true
   field_filter_title: true
-  field_ids: true
-  field_news_items_to_display: true
   field_people_add: true
   field_people_add_department: true
   field_people_list: true
   field_people_search: true
-  field_show_title: true
   field_webdir_exclude_profiles: true
   field_webdir_items_to_display: true
   field_webdir_use_pager: true

--- a/web/modules/webspark/webspark_webdir/webspark_webdir.install
+++ b/web/modules/webspark/webspark_webdir/webspark_webdir.install
@@ -248,6 +248,13 @@ function webspark_webdir_update_9012(&$sandbox): void {
 
 /**
  * Update to add field_webdir_disable_alpha to web directory block.
+ *
+ * Note: we've removed the fields we deleted in 9009 from the core.entity_*
+ * ymls we read in here, otherwise they get added back and we don't want that.
+ * For people updating from older versions, they may need to do an update to
+ * WS2 2.11.0 before they can update to WS2 2.12.0 if they encounter erorrs
+ * or want to ensure they don't lose any webdir settings. To do a stepped
+ * update see: https://docs.google.com/presentation/d/1MOOJNlFCBRsXXg4fBOL9YAUlP-x2W8TKIcWkMCdY11o/edit#slide=id.g110d8a6d565_3_0
  */
 function webspark_webdir_update_9013(&$sandbox): void {
   \Drupal::service('webspark.config_manager')->updateConfigFile('field.field.block_content.web_directory.field_component_type');


### PR DESCRIPTION
### Description

double fields in the Web Directory UI in Layout Builder from the Support hours. Looks like that’s because adding the new alpha filter, I added an update hook that updated the core.entity_form_display.block_content.web_directory.default.yml and core.entity_view_display.block_content.web_directory.default.yml files and they still have the old fields we removed a few releases back. This is the first update that’s hit those again

We need to pull those fields out of the core.entity_* ymls in webspark_webdir.

Once this builds, we need to manually re-run webspark_webdir update 9012. Because of this headache, this PR is against Dev, and when merged, I'll port that update back to the sprint branch and re-run the update on that environment, too.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1835)

