### PR TITLE
Adjusting composer files to pull in fontawesome from Asset Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,20 @@
         },
         {
             "type": "composer",
-            "url": "https://asset-packagist.org"
+            "url": "https://asset-packagist.org",
+            "exclude": ["npm-asset/fontawesome"]
+        },
+        {
+            "type": "package",
+            "package": {
+                    "name": "npm-asset/fontawesome",
+                    "version": "6.4.2",
+                    "dist": {
+                        "type": "tar",
+                        "url": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz"
+                    },
+                    "type": "npm-asset"
+            }
         },
         {
             "type": "package",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "bower-asset/fontawesome": "6.4.2",
+        "npm-asset/fontawesome": "6.4.2",
         "ckeditor/fakeobjects": "4.16.0",
         "ckeditor/link": "4.16.1",
         "composer/installers": "v2.0.0",


### PR DESCRIPTION
### Description
Composer builds are failing on sites trying to update to WS2.11, because Bower is down and Composer is unable to pull in Font Awesome from it. 

This PR pulls in Font Awesome from Asset Packagist instead. The new package being pulled in is here: https://asset-packagist.org/package/npm-asset/fortawesome--fontawesome-free 

fortawesome--fontawesome-free is renamed in the root composer.json to "fontawesome" so no code or configuration changes are needed in WS2 when this is switched out.


### Links

[- [JIRA ticket](https://asudev.jira.com/browse/WS2-1842)](https://asudev.jira.com/browse/WS2-1842)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Screenshots
![Screenshot 2023-11-02 at 3 08 02 PM](https://github.com/ASUWebPlatforms/webspark-ci/assets/6909200/599a8451-5ef0-4144-8bf2-45584e38102b)
Example of error when trying to pull in fontawesome from Bower


