### PR TITLE
WS2-1839 - The default value was added to the field_hero_background_color in blocks with type=video_hero.

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.video_hero.field_hero_background_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.video_hero.field_hero_background_color.yml
@@ -12,9 +12,11 @@ entity_type: block_content
 bundle: video_hero
 label: 'Hero Heading Background Color'
 description: ''
-required: false
+required: true
 translatable: true
-default_value: {  }
+default_value:
+  -
+    value: default
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -216,6 +216,25 @@ function webspark_blocks_update_9022(&$sandbox) {
 }
 
 /**
+ * WS2-1839 - The default value was added to the field_hero_background_color in blocks with type=video_hero.
+ */
+function webspark_blocks_update_9023() {
+  $entityTypeManager = \Drupal::entityTypeManager();
+  $blockType = 'video_hero';
+  $blockStorage = $entityTypeManager->getStorage('block_content');
+  $blockContents = $blockStorage->loadByProperties([
+    'type' => $blockType,
+  ]);
+
+  foreach ($blockContents as $blockContent) {
+    if (!isset($blockContent->field_hero_background_color->value) || empty($blockContent->field_hero_background_color->value)) {
+      $blockContent->set('field_hero_background_color', 'default');
+      $blockContent->save();
+    }
+  }
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -235,6 +235,13 @@ function webspark_blocks_update_9023() {
 }
 
 /**
+ * WS2-1839 - Add required and default value to field_hero_background_color.
+ */
+function webspark_blocks_update_9024(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
### Description
Heros that were configured to have white text have lost that configuration with the latest update to 2.11. No code errors were seen in applying the update or update hooks. 

### Solution
The default value was added to the field_hero_background_color in blocks with type=video_hero.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1839)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
