### PR TITLE
WS2-1533 - Changed description text for field_media in Card, Card Degree, Card Story

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card.field_media.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card.field_media.yml
@@ -13,7 +13,7 @@ field_name: field_media
 entity_type: paragraph
 bundle: card
 label: Media
-description: 'Recommended image size (W x H): 588 x 200 px'
+description: 'Most cards display images in a 4:3 ratio'
 required: false
 translatable: true
 default_value: {  }

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_degree.field_media.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_degree.field_media.yml
@@ -13,7 +13,7 @@ field_name: field_media
 entity_type: paragraph
 bundle: card_degree
 label: Media
-description: 'Recommended image size (W x H): 588 x 200 px'
+description: 'Most cards display images in a 4:3 ratio'
 required: false
 translatable: true
 default_value: {  }

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_story.field_media.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_story.field_media.yml
@@ -13,7 +13,7 @@ field_name: field_media
 entity_type: paragraph
 bundle: card_story
 label: Media
-description: 'Recommended image size (W x H): 588 x 200 px'
+description: 'Most cards display images in a 4:3 ratio'
 required: false
 translatable: true
 default_value: {  }

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -216,6 +216,13 @@ function webspark_blocks_update_9022(&$sandbox) {
 }
 
 /**
+ * WS2-1533 - Changed description text for field_media in Card, Card Degree, Card Story.
+ */
+function webspark_blocks_update_9025(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
### Description

### Description of problem 
When adding a new card to an existing layout component there are recommendation text that indicates the image should be 588 x 200 px but when uploading an image that fits that size the image is then forced to crop to a 4x3 ratio size.

### Solution
Changed description text for field_media in Card, Card Degree, Card Story

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1533)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
