### PR TITLE
WS2 1800: Ranking card 'read more' 'Link' field now optional

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_ranking.field_link.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_ranking.field_link.yml
@@ -1,3 +1,4 @@
+uuid: 4f3f0a77-7213-47c5-b306-ec76918ceffa
 langcode: en
 status: true
 dependencies:
@@ -12,7 +13,7 @@ entity_type: paragraph
 bundle: card_ranking
 label: Link
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_ranking.field_link.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.paragraph.card_ranking.field_link.yml
@@ -1,4 +1,3 @@
-uuid: 4f3f0a77-7213-47c5-b306-ec76918ceffa
 langcode: en
 status: true
 dependencies:

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -254,6 +254,16 @@ function webspark_blocks_update_9025(&$sandbox) {
 }
 
 /**
+ * WS2-1800 - Ranking card "read more" "Link" field now optional.
+ */
+function webspark_blocks_update_9026(&$sandbox) {
+  $configs = [
+    'field.field.paragraph.card_ranking.field_link',
+  ];
+  _webspark_blocks_update_module_config_list($configs);
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1800)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
