### PR TITLE
Enable drag-and-drop functionality

### DIFF
--- a/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_asurite_ids.yml
+++ b/web/modules/webspark/webspark_webdir/config/install/field.field.block_content.web_directory.field_asurite_ids.yml
@@ -9,7 +9,7 @@ field_name: field_asurite_ids
 entity_type: block_content
 bundle: web_directory
 label: Profiles
-description: '<span class="description form-text text-muted">*Click on a profile to remove it from the list.</span>'
+description: '<span class="description form-text text-muted">*Click on a profile to remove it from the list. Click and drag to reorder list items.</span>'
 required: false
 translatable: false
 default_value: {  }

--- a/web/modules/webspark/webspark_webdir/css/directory-field.css
+++ b/web/modules/webspark/webspark_webdir/css/directory-field.css
@@ -52,3 +52,18 @@
 #profiles-control-options-list .right-control:hover {
   border-bottom: 1px solid rgb(221, 221, 221);
 }
+#asurite-tree-options .jstree-node a.jstree-anchor {
+  cursor: move;
+  display: flex;
+}
+
+#asurite-tree-options .jstree-node {
+  border-radius: 5px;
+  padding: 2px;
+  margin-bottom: 6px;
+  border: 1px solid #ccc;
+}
+
+#asurite-tree-options .jstree-node i {
+  display: none;
+}

--- a/web/modules/webspark/webspark_webdir/js/asurite-field.js
+++ b/web/modules/webspark/webspark_webdir/js/asurite-field.js
@@ -54,6 +54,12 @@
             // Recreate tree with the default values.
             update_tree(values);
           });
+
+          $("#asurite-tree-options").on('move_node.jstree', () => {
+              const sortableList = $('#asurite-tree-options li');
+              const idString = Array.from(sortableList).map(node => node.id).toString();
+              $('.asurite-tree').val(idString);
+          });
         });
       }
     }
@@ -82,18 +88,19 @@
       $('#asurite-tree-options').jstree({
         'core' : {
           'data' : converted_json,
-          'themes' : { dots: false }
+          'themes' : { dots: false },
+          'check_callback' : true
         },
         types: {
           "person": {
-            "icon" : "fa fa-user"
+            "icon" : "fa fa-user",
+            "valid_children" : [],
           },
           "default" : {
           }
         },
-        "plugins" : [ "types" ]
+        "plugins" : [ "types", "dnd" ],
       });
-
     }, "json");
 
   }

--- a/web/modules/webspark/webspark_webdir/webspark_webdir.install
+++ b/web/modules/webspark/webspark_webdir/webspark_webdir.install
@@ -264,6 +264,13 @@ function webspark_webdir_update_9013(&$sandbox): void {
   \Drupal::service('webspark.config_manager')->updateConfigFile('field.storage.block_content.field_webdir_disable_alpha');
 }
 
+/**
+ * Enable reordering of items in 'People' and 'People in Departments' listings.
+ */
+function webspark_webdir_update_9014(&$sandbox): void {
+  \Drupal::service('webspark.config_manager')->updateConfigFile('field.field.block_content.web_directory.field_asurite_ids');
+}
+
 // @todo This module doesn't implement hook_config_readonly_whitelist_patterns()
 // We should add that eventually. Likelihood of users tweaking this block's
 // field settings is low, no not a rush.

--- a/web/modules/webspark/webspark_webdir/webspark_webdir.module
+++ b/web/modules/webspark/webspark_webdir/webspark_webdir.module
@@ -58,7 +58,7 @@ function webspark_webdir_preprocess_block__web_directory(&$variables)
     // Because some titles have commas and ampersands in them, we need to
     // split the data and encode it before we use a comma as a separator in JS.
     $value = $blockContent->field_filter_title->value;
-    $array = preg_split('/\r?\n|\r/', $value);
+    $array = !empty($value) ? preg_split('/\r?\n|\r/', $value) : [];
     $array = array_map(function($value) {
       return rawurlencode($value);
     }, $array);


### PR DESCRIPTION
### Description

<!-- Description of problem -->
People want to re-order listings done in the 'People' and 'People in Departments' listings. 
<!-- Solution -->
Solution: Leverage the native drag-and-drop functionality of jsTree and then rewrite the text field after dragging and dropping has finished.

To test:
1. Log into the PR site and navigate to the Web Directory page
2. Click "Layout" and then click on the pencil icon for either the "People" or "People in Departments" listing block and then click "configure."
3. In the "Profiles" section, test the drag and drop functionality by moving people up or down in the list.
4. Make sure that the "Default sort" option is set to "Sort by order people added"
5. Click the "update" button, and then click the "Save Layout" button in Layout Builder.
6. The directory listing should reflect the order which you created via drag-and-drop

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1851)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
