### PR TITLE
WS2-1875: Added new styles for layout builder to have compatibility for Drupal 10

### DIFF
--- a/web/themes/webspark/renovation/src/sass/layout-builder.scss
+++ b/web/themes/webspark/renovation/src/sass/layout-builder.scss
@@ -2,7 +2,9 @@
 @import "node_modules/@asu/unity-bootstrap-theme/src/scss/custom-asu-variables";
 @import "base/mixins";
 
-#drupal-off-canvas {
+#drupal-off-canvas-wrapper  {
+  padding-right: 0;
+
   .form-text,
   .form-tel,
   .form-email,
@@ -183,6 +185,21 @@
   .draggable a.tabledrag-handle .handle {
     height: 18px;
     mask: inherit;
+  }
+
+  .ui-dialog-titlebar {
+    position: sticky;
+    z-index: 1;
+    top: 0;
+    margin-right: 0;
+  }
+
+  #drupal-off-canvas {
+    padding-bottom: 20px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 68vh !important;
+    padding-right: 20px;
   }
 }
 


### PR DESCRIPTION


### Description

<!-- Description of problem -->
### Solution
Added new styles for layout builder to have compatibility for Drupal 10

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1875)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
