### PR TITLE
fix webspark_cas module

### DIFF
--- a/web/modules/webspark/webspark_cas/src/EventSubscriber/WebSparkCasSubscriber.php
+++ b/web/modules/webspark/webspark_cas/src/EventSubscriber/WebSparkCasSubscriber.php
@@ -2,24 +2,24 @@
 
 namespace Drupal\webspark_cas\EventSubscriber;
 
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Drupal\cas\Subscriber\CasRouteSubscriber;
+use Drupal\cas\Subscriber\CasGatewayAuthSubscriber;
 use Drupal\Core\Site\Settings;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
  * WebSpark CAS event subscriber.
  */
-class WebSparkCasSubscriber extends CasRouteSubscriber {
+class WebSparkCasSubscriber extends CasGatewayAuthSubscriber {
 
   /**
    * {@inheritdoc}
    */
-  public function handle(RequestEvent $event) {
-    if ($this->isElasticCrawlerRequest() && !$this->isForcedPath()) {
+  public function onRequest(RequestEvent $event) {
+    if ($this->isElasticCrawlerRequest()) {
       return;
     }
 
-    return parent::handle($event);
+    return parent::onRequest($event);
   }
 
   /**
@@ -48,20 +48,6 @@ class WebSparkCasSubscriber extends CasRouteSubscriber {
     }
 
     return FALSE;
-  }
-
-  /**
-   * Checks if the path is a forced login one.
-   *
-   * @see https://stackoverflow.com/a/61921662
-   *
-   * @return bool
-   *   The check result.
-   */
-  protected function isForcedPath() {
-    $r = new \ReflectionMethod(parent::class, 'handleForcedPath');
-    $r->setAccessible(TRUE);
-    return $r->invoke($this);
   }
 
 }

--- a/web/modules/webspark/webspark_cas/src/WebsparkCasServiceProvider.php
+++ b/web/modules/webspark/webspark_cas/src/WebsparkCasServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\webspark_cas;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+
+/**
+ * Modifies the cas.gateway_subscriber service.
+ */
+class WebsparkCasServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * Alters the cas.gateway_subscriber service.
+   *
+   * See https://drupal.stackexchange.com/questions/288814/is-it-possible-to-override-replace-an-event-subscriber.
+   *
+   * @param \Drupal\Core\DependencyInjection\ContainerBuilder $container
+   *   The container builder.
+   */
+  public function alter(ContainerBuilder $container) {
+    // Overrides cas.gateway_subscriber class.
+    if ($container->hasDefinition('cas.gateway_subscriber')) {
+      $definition = $container->getDefinition('cas.gateway_subscriber');
+      $definition->setClass('Drupal\webspark_cas\EventSubscriber\WebSparkCasSubscriber');
+    }
+  }
+
+}

--- a/web/modules/webspark/webspark_cas/webspark_cas.services.yml
+++ b/web/modules/webspark/webspark_cas/webspark_cas.services.yml
@@ -1,6 +1,0 @@
-services:
-  cas.subscriber:
-    class: Drupal\webspark_cas\EventSubscriber\WebSparkCasSubscriber
-    arguments: ['@request_stack', '@current_route_match', '@config.factory',  '@current_user', '@plugin.manager.condition', '@cas.helper', '@cas.redirector']
-    tags:
-      - { name: event_subscriber }


### PR DESCRIPTION
### Description

<!-- Description of problem -->
Problem: The wrong Class was being used, which broke this module's functionality.
<!-- Solution -->
Solution: We needed to not only use the correct class, but also to override the Event Subscriber service so that our code fires first. This was done via a new class WebsparkCasServiceProvider which implements the ServiceModifierInterface.

I have removed the code checking for whether it is a forced path, since that is handled by a separate "new" class in the CAS module now. I have also removed the service definition; since we are hijacking the other service, we don't need to load this service with a separate service definition. 
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1877)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
