### PR TITLE
Ws2 2 12 0 release fixes

### DIFF
--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -301,3 +301,19 @@ function _webspark_blocks_update_module_config_list($config_list = []) {
   }
   \Drupal::state()->set('configuration_locked', TRUE);
 }
+
+/**
+ * Ensure required updates happen before they are needed here.
+ */
+function webspark_blocks_update_dependencies() {
+
+  // Indicate that the webspark_blocks_update_9024() function provided by this module
+  // must run after the webspark_update_9018() function provided by the
+  // 'webspark' profile. Otherwise we might try and import ckeditor5 related configs
+  // before it has been installed, and generate errors.
+  $dependencies['webspark_blocks'][9024] = [
+    'webspark' => 9018,
+  ];
+
+  return $dependencies;
+}

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -12,6 +12,7 @@ install:
   - block
   - breakpoint
   - ckeditor
+  - ckeditor5
   - color
   - config
   - comment


### PR DESCRIPTION
### Description

Ran into an issue where we needed to ensure the profile update that installed ckeditor5 ran before the webspark_blocks config import. 

This sets that right by implementing https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_dependencies/10

It also corrects an oversight where ckeditor5 isn't installed for new sites.