### PR TITLE
WS2-1871: Added hook_update to uninstall ckeditor/fakeobjects module

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -3,10 +3,6 @@
         "#2951547: Fix issue with layout overflow": "https://www.drupal.org/files/issues/2022-07-13/f245f21ea664f22c81d8d28c6f0f4a42fb9a5890.patch",
         "3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2021-09-22/core-9.2-xss-refactor_filter_attributes-3109650-43.patch"
     },
-        "drupal/fakeobjects": {
-        "3002953: Fix js plugin seems to be missing": "https://www.drupal.org/files/issues/2020-06-22/fakeobjects-missing_plugin-3002953-5.patch",
-        "3356461: Remove dependency on ckeditor4":"https://www.drupal.org/files/issues/2023-06-05/remove-dependency-on-ckeditor-3356461-6.patch"
-    },
     "drupal/config_readonly": {
         "#3085001: Config blacklist to only block some configuration while in read only mode": "https://www.drupal.org/files/issues/2019-10-31/config_readonly-3085001-2.patch"
     },

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -1,6 +1,6 @@
 name: Webspark
 type: profile
-core_version_requirement: ^9.0
+core_version_requirement: ^9.0 || ^10
 description: 'ASU custom profile.'
 version: 2.12.0
 distribution:

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -371,7 +371,7 @@ function webspark_update_9019(&$sandbox) {
  * WS2-1871 : Uninstall FakeObjects module.
  */
 function webspark_update_9020(&$sandbox) {
-  if (Drupal::moduleHandler()->moduleExists('ckeditor/fakeobjects')) {
-    Drupal::service('module_installer')->uninstall(['ckeditor/fakeobjects']);
+  if (Drupal::moduleHandler()->moduleExists('fakeobjects')) {
+    Drupal::service('module_installer')->uninstall(['fakeobjects']);
   }
 }

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -366,3 +366,12 @@ function webspark_update_9019(&$sandbox) {
   \Drupal::state()->set('configuration_locked', TRUE);
 
 }
+
+/**
+ * WS2-1871 : Uninstall FakeObjects module.
+ */
+function webspark_update_9020(&$sandbox) {
+  if (Drupal::moduleHandler()->moduleExists('ckeditor/fakeobjects')) {
+    Drupal::service('module_installer')->uninstall(['ckeditor/fakeobjects']);
+  }
+}


### PR DESCRIPTION
### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-0000)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
