### PR TITLE
WS2 2.12.0 release - fix ckeditor toolbar stickiness on node forms

### DIFF
--- a/web/modules/webspark/webspark_ckeditor_plugins/css/websparkglobal.css
+++ b/web/modules/webspark/webspark_ckeditor_plugins/css/websparkglobal.css
@@ -9,6 +9,18 @@ div.ck.ck-content.ck-editor__editable {
   width: 100% !important;
   z-index: 99 !important;
 }
+/* Node edit forms need to avoid admin toolbar overlappig wysiwyg */
+/* When admin toolbar horizontal */
+body.toolbar-fixed.toolbar-horizontal form.node-page-edit-form .ck-editor__top {
+  top: 36px !important;
+}
+body.toolbar-fixed.toolbar-horizontal.toolbar-tray-open form.node-page-edit-form .ck-editor__top {
+  top: 76px !important;
+}
+/* When admin toolbar vertical */
+body.toolbar-fixed.toolbar-vertical form.node-page-edit-form .ck-editor__top {
+  top: 36px !important;
+}
 
 .ck-sticky-panel__placeholder {
   display: none !important;


### PR DESCRIPTION
### Description

Late in the prep for release I discovered the admin toolbar overlaps the sticky ckeditor toolbar when scrolling on node edit forms. This update fixes that. 

Before: if you were on a node edit form and scrolled past the top of the body text area, the WYSIWYG form gets covered over by the admin toolbar

Note: The CSS rules are scoped so they shouldn't interfere with the Layout Builder wysiwyg rules and they shouldn't apply if someone has turned off the admin toolbar. They also adapt to the various modes of the admin toolbar.  The rules are scoped to the `form.node-page-edit-form`. We may find in the future we want to open that up further (as long as we avoid regressing the Layout Builder rules).

Testing:
* Verify that when you scroll on the node edit form, the WYSIWYG editor toolbar remains visible and sticky below the admin toolbar.  
* Try adjusting the admin toolbar and ensure the WYSIWYG editor toolbar remains sticky and visible below what remains of the toolbar at the top of the screen without a gap:
  * open/close the tray
  * set the tray to vertical/horizontal
* Test the Layout Builder text content component and ensure we haven't regressed the sticky behavior there.


### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1883)

