### PR TITLE
WS2-1888: Delete empty property in fieldset and adjust comment spacing.

### DIFF
--- a/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
+++ b/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
@@ -66,7 +66,6 @@ class WebsparkBlocksAdminSettings extends ConfigFormBase {
       $form['links_fieldset']['link_fieldset'. $i] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Link'),
-         ''
       ];
       $form['links_fieldset']['link_fieldset'. $i]['link_url'] = [
         '#type' => 'textfield',
@@ -112,7 +111,7 @@ class WebsparkBlocksAdminSettings extends ConfigFormBase {
   }
 
 
-   /**
+  /**
    * Callback for both ajax-enabled buttons.
    *
    * Selects and returns the fieldset with the names in it.


### PR DESCRIPTION
### Description

Webspark blocks admin pageview throws error in watchdog logs.
<!-- Solution -->
Remove empty property in the fieldset form element in web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1888)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

Note: Sections that are not applicable for this issue can be removed.
