### PR TITLE
Ws2 1889: JSM - WS2 - Cards, grid links, and anchor menu items with icons (Webspark Test)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3058,17 +3058,17 @@
         },
         {
             "name": "drupal/entity_reference_revisions",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_reference_revisions.git",
-                "reference": "8.x-1.10"
+                "reference": "8.x-1.11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_reference_revisions-8.x-1.10.zip",
-                "reference": "8.x-1.10",
-                "shasum": "edd23b91c4a34db65ea22c4db54b7458edc7513b"
+                "url": "https://ftp.drupal.org/files/projects/entity_reference_revisions-8.x-1.11.zip",
+                "reference": "8.x-1.11",
+                "shasum": "de21cbb0d8a0344dc3496addcad4ed536747cec5"
             },
             "require": {
                 "drupal/core": "^9 || ^10"
@@ -3079,8 +3079,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.10",
-                    "datestamp": "1660664712",
+                    "version": "8.x-1.11",
+                    "datestamp": "1705140721",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3513,26 +3513,29 @@
         },
         {
             "name": "drupal/fontawesome",
-            "version": "dev-2.x",
+            "version": "2.26.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/fontawesome.git",
-                "reference": "65e140fe9124b65ef7862e266fddf50382580264"
+                "reference": "8.x-2.26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/fontawesome-8.x-2.26.zip",
+                "reference": "8.x-2.26",
+                "shasum": "22e67458e1ebc274c3a8b494ce2c4056a3d2af29"
             },
             "require": {
                 "drupal/core": "^9.4 || ^10"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-2.26+6-dev",
-                    "datestamp": "1694619484",
+                    "version": "8.x-2.26",
+                    "datestamp": "1688063477",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -6190,25 +6193,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -6216,7 +6221,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -6240,9 +6245,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.0"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-01-07T17:17:35+00:00"
         },
         {
             "name": "northernco/ckeditor5-anchor-drupal",
@@ -6421,7 +6426,7 @@
             "dist": {
                 "type": "path",
                 "url": "upstream-configuration",
-                "reference": "884af98916aebdbeb9b544f62c64a674fe0d4b88"
+                "reference": "056a878f84fe21a2839d5ee424fc174a18341b06"
             },
             "require": {
                 "ckeditor/fakeobjects": "4.16.0",
@@ -6454,7 +6459,7 @@
                 "drupal/field_group": "3.4.0",
                 "drupal/field_menu": "2.1.0",
                 "drupal/field_states_ui": "3.0",
-                "drupal/fontawesome": "2.x-dev@dev",
+                "drupal/fontawesome": "2.26.0",
                 "drupal/image_widget_crop": "2.4.0",
                 "drupal/imagemagick": "3.6.0",
                 "drupal/layout_builder_component_attributes": "2.1.1",
@@ -6732,23 +6737,23 @@
         },
         {
             "name": "phenx/php-font-lib",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/php-font-lib.git",
-                "reference": "dd448ad1ce34c63d09baccd05415e361300c35b4"
+                "reference": "671df0f3516252011aa94f9e8e3b3b66199339f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/dd448ad1ce34c63d09baccd05415e361300c35b4",
-                "reference": "dd448ad1ce34c63d09baccd05415e361300c35b4",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/671df0f3516252011aa94f9e8e3b3b66199339f8",
+                "reference": "671df0f3516252011aa94f9e8e3b3b66199339f8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^3 || ^4 || ^5"
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
             },
             "type": "library",
             "autoload": {
@@ -6758,7 +6763,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-2.1-or-later"
             ],
             "authors": [
                 {
@@ -6770,9 +6775,9 @@
             "homepage": "https://github.com/PhenX/php-font-lib",
             "support": {
                 "issues": "https://github.com/dompdf/php-font-lib/issues",
-                "source": "https://github.com/dompdf/php-font-lib/tree/0.5.4"
+                "source": "https://github.com/dompdf/php-font-lib/tree/0.5.5"
             },
-            "time": "2021-12-17T19:44:54+00:00"
+            "time": "2024-01-07T18:13:29+00:00"
         },
         {
             "name": "phootwork/collection",
@@ -11978,21 +11983,21 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.2.4",
+            "version": "1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "57b2cc67fb4416e8484db37a3d8502ac8fb3c0d6"
+                "reference": "ba8678f8cbea42cc41022c21751004eb677cf5a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/57b2cc67fb4416e8484db37a3d8502ac8fb3c0d6",
-                "reference": "57b2cc67fb4416e8484db37a3d8502ac8fb3c0d6",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/ba8678f8cbea42cc41022c21751004eb677cf5a4",
+                "reference": "ba8678f8cbea42cc41022c21751004eb677cf5a4",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^1.10.1",
+                "phpstan/phpstan": "^1.10.56",
                 "phpstan/phpstan-deprecation-rules": "^1.1.4",
                 "symfony/finder": "^4.2 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/yaml": "^4.2|| ^5.0 || ^6.0 || ^7.0",
@@ -12062,7 +12067,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.4"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.6"
             },
             "funding": [
                 {
@@ -12078,7 +12083,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-14T22:47:32+00:00"
+            "time": "2024-01-16T00:42:10+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -12491,16 +12496,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.7.3",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419"
+                "reference": "fad452781b3d774e3337b0c0b245dd8e5a4455fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
-                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fad452781b3d774e3337b0c0b245dd8e5a4455fc",
+                "reference": "fad452781b3d774e3337b0c0b245dd8e5a4455fc",
                 "shasum": ""
             },
             "require": {
@@ -12543,9 +12548,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.3"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.0"
             },
-            "time": "2023-08-12T11:01:26+00:00"
+            "time": "2024-01-11T11:49:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -12714,16 +12719,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.5",
+            "version": "1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
                 "shasum": ""
             },
             "require": {
@@ -12755,22 +12760,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
             },
-            "time": "2023-12-16T09:33:33+00:00"
+            "time": "2024-01-04T17:06:16+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.50",
+            "version": "1.10.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/27816a01aea996191ee14d010f325434c0ee76fa",
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa",
                 "shasum": ""
             },
             "require": {
@@ -12819,7 +12824,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T10:59:42+00:00"
+            "time": "2024-01-15T10:43:00+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -14722,16 +14727,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -14741,11 +14746,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -14798,7 +14803,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -30,7 +30,7 @@
         "drupal/field_group": "3.4.0",
         "drupal/field_menu": "2.1.0",
         "drupal/field_states_ui": "3.0",
-        "drupal/fontawesome": "2.x-dev@dev",
+        "drupal/fontawesome": "2.26.0",
         "drupal/image_widget_crop": "2.4.0",
         "drupal/imagemagick": "3.6.0",
         "drupal/layout_builder_component_attributes": "2.1.1",

--- a/web/themes/webspark/renovation/css/layout-builder.css
+++ b/web/themes/webspark/renovation/css/layout-builder.css
@@ -102,9 +102,33 @@
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
-#drupal-off-canvas-wrapper .icons-selector.fip-grey .fip-box:hover,
-#drupal-off-canvas-wrapper .icons-selector .selected-icon {
-  color: var(--bs-table-color-state, var(--bs-table-color-type, var(--bs-table-color)));
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .fip-icon-block:before {
+  color: #f54848;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .selector-search i {
+  color: #999;
+  top: 3px;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .selector-search .icons-search-input::-moz-placeholder {
+  color: #999 !important;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .selector-search .icons-search-input::placeholder {
+  color: #999 !important;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .fip-box {
+  color: #333;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .fip-box:hover {
+  color: #000;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .selector-pages, #drupal-off-canvas-wrapper .icons-selector.fip-grey .selector-arrows i {
+  color: #999;
+}
+#drupal-off-canvas-wrapper .icons-selector.fip-grey .selected-icon {
+  color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 #drupal-off-canvas-wrapper fieldset {
   background: inherit;

--- a/web/themes/webspark/renovation/includes/theme.inc
+++ b/web/themes/webspark/renovation/includes/theme.inc
@@ -93,6 +93,10 @@ function renovation_theme_suggestions_input_alter(array &$suggestions, array $va
     // Specifically for radio inputs on color selector.
     $suggestions[] = $variables['theme_hook_original'] . '__' . 'field_banner_background_color';
   }
+  if (isset($element['#name']) && preg_match('/^settings\[block_form\].*?\[field_icon\]/', $element['#name'])) {
+    // Target the Fontawesome icon picker widget.
+    $suggestions[] = $variables['theme_hook_original'] . '__' . 'settings_block_subform_field_icon';
+  }
 }
 
 /**

--- a/web/themes/webspark/renovation/src/sass/layout-builder.scss
+++ b/web/themes/webspark/renovation/src/sass/layout-builder.scss
@@ -151,9 +151,34 @@
     margin-bottom: 0.5rem;
   }
 
-  .icons-selector.fip-grey .fip-box:hover,
-  .icons-selector .selected-icon {
-    color: var(--bs-table-color-state, var(--bs-table-color-type, var(--bs-table-color)));
+  .icons-selector.fip-grey {
+    .fip-icon-block:before {
+      color: #f54848;
+    }
+    .selector-search {
+      i {
+        color: #999;
+        top: 3px;
+      }
+      .icons-search-input::placeholder {
+        color: #999 !important;
+      }
+    }
+    .fip-box {
+      color: #333;
+    }
+    .fip-box:hover {
+      color: #000;
+    }
+    .selector-pages, .selector-arrows i {
+      color: #999;
+    }
+    .selected-icon {
+      color: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   fieldset {

--- a/web/themes/webspark/renovation/templates/form/input--textfield--settings_block_subform_field_icon.html.twig
+++ b/web/themes/webspark/renovation/templates/form/input--textfield--settings_block_subform_field_icon.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+{% if type != 'file' %}
+  {% set css_classes = ['form-control'] %}
+{% endif %}
+<div class="ck-reset">
+  <input{{ attributes.addClass(css_classes).removeClass('form-text') }} />
+  {{ children }}
+</div>


### PR DESCRIPTION
### Description

The FontAwesome iconpicker widget was broken within the off-canvas dialogue due to its style reset that was introduced in Drupal 10.0.0.

The solution was to wrap it in a class that is allowed through the style reset fence. I have also improved some of the CSS so that it is more accessible/legible and pinned the version to a stable release.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-0000)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
