### PR TITLE
Ws2 1486 stackable headings

### DIFF
--- a/web/modules/webspark/asu_brand/asu_brand.module
+++ b/web/modules/webspark/asu_brand/asu_brand.module
@@ -164,8 +164,7 @@ function asu_brand_form_menu_link_content_form_alter(array &$form, FormStateInte
         <li>Create columns by configuring "Heading" or "Column break" menu
         items at the second level. These special menu items will not render as
         links, but will instead start new columns unless they are labelled as
-        "stackable." Use &lt;nolink&gt; as
-        their link value.</li>
+        "stackable." Use &lt;nolink&gt; as their link value.</li>
         <li>When you configure a second level menu item as a button within a
         column, please ensure it is the last item in a column, otherwise it may
         render incorrectly in the mobile menu.</li>

--- a/web/modules/webspark/asu_brand/asu_brand.module
+++ b/web/modules/webspark/asu_brand/asu_brand.module
@@ -34,6 +34,7 @@ function asu_brand_entity_base_field_info(EntityTypeInterface $entity_type) {
         'allowed_values' => [
           //'icon' => 'Icon', // First link always becomes icon. Not allowing select for this.
           'heading' => 'Heading - starts a column',
+          'stackable heading' => 'Heading - stackable in a column',
           'column break' => 'Column break - starts a column without a heading',
           'button' => 'Button - within column',
         ],
@@ -162,7 +163,8 @@ function asu_brand_form_menu_link_content_form_alter(array &$form, FormStateInte
         ASU Brand Headers.</li>
         <li>Create columns by configuring "Heading" or "Column break" menu
         items at the second level. These special menu items will not render as
-        links, but will instead start new columns. Use &lt;nolink&gt; as
+        links, but will instead start new columns unless they are labelled as
+        "stackable." Use &lt;nolink&gt; as
         their link value.</li>
         <li>When you configure a second level menu item as a button within a
         column, please ensure it is the last item in a column, otherwise it may

--- a/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -626,6 +626,11 @@ class AsuBrandHeaderBlock extends BlockBase {
       if ($tripwire && ($v['type'] === "heading" || $v['type'] === "column break")) {
         $col++;
       }
+
+      // "stackable heading" is a concept on the module side only. Converting
+      // to "heading" now for use in props. See WS2-1486
+      $v['type'] = ($v['type'] === "stackable heading") ? "heading" : $v['type'];
+
       $childItemCols[$col][] = $v;
       // We want first heading/column to stay in 0, so trigger here.
       // All subsequent passes will use new columns.


### PR DESCRIPTION
### Description

`component-header` supports multiple headers in a dropdown column, but we didn't have a way to define that on the `asu_brand` module side. 

Adds a `stackable heading` menu item config that is skipped in the navTree prop logic that turns headings into new columns, and then gets converted to the `heading` type after that processing so it's sent to the component with a valid type. This enables stacking of sections with more than one header in a column. 

### Steps to Test

Edit the main menu used in a header…

1. You will need a drop down with multiple columns.
2. Add a new column using a “Heading - starts a new column” and ensure that works as it did originally. (Testing that we don’t have any regressions).
3. Now change that new column menu item to a “Column break…” item. There should still be a column for that menu item, but it will now not be a heading. (Another regression test).
4. Now change that menu item to a “Heading - stackable in a column” menu link type.  It should now not start a new column and instead should fall “stacked” in the column “preceding” it.
5. On the menu overview page (`/admin/structure/menu/manage/main` for the main menu) verify that the “Header settings” column correctly lists the special menu item types, including “stackable heading”.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1486)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant