### PR TITLE
WS2-1727 sync default.robots.txt

### DIFF
--- a/web/sites/default/default.robots.txt
+++ b/web/sites/default/default.robots.txt
@@ -37,7 +37,15 @@ Allow: /profiles/*.svg
 Disallow: /core/
 Disallow: /profiles/
 # Files
-Disallow: /README.txt
+Disallow: /README.md
+Disallow: /composer/Metapackage/README.txt
+Disallow: /composer/Plugin/ProjectMessage/README.md
+Disallow: /composer/Plugin/Scaffold/README.md
+Disallow: /composer/Plugin/VendorHardening/README.txt
+Disallow: /composer/Template/README.txt
+Disallow: /modules/README.txt
+Disallow: /sites/README.txt
+Disallow: /themes/README.txt
 Disallow: /web.config
 # Paths (clean URLs)
 Disallow: /admin/
@@ -49,6 +57,8 @@ Disallow: /user/register
 Disallow: /user/password
 Disallow: /user/login
 Disallow: /user/logout
+Disallow: /media/oembed
+Disallow: /*/media/oembed
 # Paths (no clean URLs)
 Disallow: /index.php/admin/
 Disallow: /index.php/comment/reply/
@@ -58,3 +68,6 @@ Disallow: /index.php/search/
 Disallow: /index.php/user/password
 Disallow: /index.php/user/register
 Disallow: /index.php/user/login
+Disallow: /index.php/user/logout
+Disallow: /index.php/media/oembed
+Disallow: /index.php/*/media/oembed


### PR DESCRIPTION
### Description

We need to keep our reference "site owner managed files" in sync with D10 references. Most are not included in our repo and get built out by scaffolding and/or composer, but the default.robots.txt is one we provide. So updating it here to match https://git.drupalcode.org/project/drupal/-/blob/10.2.2/robots.txt?ref_type=tags

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1727)
