### PR TITLE
Ws2 1871: Clean up CKEditor required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,30 +30,6 @@
         {
             "type": "package",
             "package": {
-                "name": "ckeditor/link",
-                "version": "4.16.1",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/link/releases/link_4.16.1.zip",
-                    "type": "zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "ckeditor/fakeobjects",
-                "version": "4.16.0",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.16.0.zip",
-                    "type": "zip"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
                 "name": "northernco/ckeditor5-anchor-drupal",
                 "version": "0.4.0",
                 "type": "drupal-library",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f4786f26869d7f0275a172cf6b55b15",
+    "content-hash": "37b960060723ffa2138e858c453f1351",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -121,24 +121,6 @@
                 "source": "https://github.com/Chi-teck/drupal-code-generator/tree/3.3.0"
             },
             "time": "2023-10-21T12:57:05+00:00"
-        },
-        {
-            "name": "ckeditor/fakeobjects",
-            "version": "4.16.0",
-            "dist": {
-                "type": "zip",
-                "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.16.0.zip"
-            },
-            "type": "drupal-library"
-        },
-        {
-            "name": "ckeditor/link",
-            "version": "4.16.1",
-            "dist": {
-                "type": "zip",
-                "url": "https://download.ckeditor.com/link/releases/link_4.16.1.zip"
-            },
-            "type": "drupal-library"
         },
         {
             "name": "composer/installers",
@@ -6425,15 +6407,13 @@
         },
         {
             "name": "pantheon-upstreams/upstream-configuration",
-            "version": "3.0.0",
+            "version": "2.12.0",
             "dist": {
                 "type": "path",
                 "url": "upstream-configuration",
-                "reference": "d727986be43f200a25234c54624ce224e251e695"
+                "reference": "9b09b5f6dfa191d71d9049fd905d3f02a99633aa"
             },
             "require": {
-                "ckeditor/fakeobjects": "4.16.0",
-                "ckeditor/link": "4.16.1",
                 "composer/installers": "v2.0.0",
                 "cweagans/composer-patches": "1.7.1",
                 "drupal/admin_toolbar": "3.4.2",
@@ -13250,16 +13230,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -13333,7 +13313,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -13349,7 +13329,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "react/promise",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -2,8 +2,6 @@
     "name": "pantheon-upstreams/upstream-configuration",
     "type": "project",
     "require": {
-        "ckeditor/fakeobjects": "4.16.0",
-        "ckeditor/link": "4.16.1",
         "composer/installers": "v2.0.0",
         "cweagans/composer-patches": "1.7.1",
         "drupal/admin_toolbar": "3.4.2",

--- a/web/profiles/webspark/webspark/config/install/editor.editor.basic_html.yml
+++ b/web/profiles/webspark/webspark/config/install/editor.editor.basic_html.yml
@@ -44,6 +44,11 @@ settings:
         - heading3
         - heading4
         - heading5
+    ckeditor5_imageResize:
+      allow_resize: true
+    ckeditor5_list:
+      reversed: false
+      startIndex: false
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<dl>'
@@ -63,17 +68,17 @@ settings:
         - '<h2 id>'
         - '<img class>'
         - '<ul class>'
-        - '<svg title role viewBox class>'
-    ckeditor5_list:
-      reversed: false
-      startIndex: false
-    ckeditor5_imageResize:
-      allow_resize: true
-    media_media:
-      allow_view_mode_override: true
+    editor_advanced_link_link:
+      enabled_attributes:
+        - class
+        - id
+        - target
+        - title
     linkit_extension:
       linkit_enabled: true
       linkit_profile: default
+    media_media:
+      allow_view_mode_override: true
 image_upload:
   status: true
   scheme: public

--- a/web/profiles/webspark/webspark/config/install/editor.editor.full_html.yml
+++ b/web/profiles/webspark/webspark/config/install/editor.editor.full_html.yml
@@ -44,18 +44,24 @@ settings:
         - heading4
         - heading5
         - heading6
-    ckeditor5_sourceEditing:
-      allowed_tags: {  }
+    ckeditor5_imageResize:
+      allow_resize: true
     ckeditor5_list:
       reversed: true
       startIndex: true
-    ckeditor5_imageResize:
-      allow_resize: true
-    media_media:
-      allow_view_mode_override: false
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+    editor_advanced_link_link:
+      enabled_attributes:
+        - class
+        - id
+        - target
+        - title
     linkit_extension:
       linkit_enabled: true
       linkit_profile: default
+    media_media:
+      allow_view_mode_override: false
 image_upload:
   status: true
   scheme: public

--- a/web/profiles/webspark/webspark/config/install/editor.editor.minimal_format.yml
+++ b/web/profiles/webspark/webspark/config/install/editor.editor.minimal_format.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.minimal_format
+  module:
+    - ckeditor5
+format: minimal_format
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - heading
+      - bold
+      - italic
+      - '|'
+      - link
+      - sourceEditing
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+    editor_advanced_link_link:
+      enabled_attributes:
+        - class
+        - id
+        - target
+        - title
+    linkit_extension:
+      linkit_enabled: false
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/web/profiles/webspark/webspark/config/install/filter.format.basic_html.yml
+++ b/web/profiles/webspark/webspark/config/install/filter.format.basic_html.yml
@@ -19,7 +19,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p class="lead"> <h1> <h2 id> <h3 id> <h4 id> <h5 id> <dl> <dt> <dd> <mark> <cite class> <blockquote cite class> <svg title role viewbox class> <path d fill> <button class="uds-tooltip"> <ol class> <drupal-media data-spacing-top data-spacing-bottom data-spacing-left data-spacing-right data-round title data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <strong> <em> <a href data-entity-type data-entity-uuid data-entity-substitution class target role name hreflang> <ul> <li> <hr class="copy-divider"> <img class src alt height width data-entity-uuid data-entity-type data-caption data-align> <div class> <i class data-fa-transform> <span class data-fa-transform> <section class="simple-box"> <table> <tr rowspan colspan> <td rowspan colspan> <th rowspan colspan class="normal indent"> <thead> <tbody> <tfoot> <caption> <ul class>'
+      allowed_html: '<br> <p class="lead"> <h1> <h2 id> <h3 id> <h4 id> <h5 id> <dl> <dt> <dd> <mark> <cite class> <blockquote cite class> <svg title role viewbox class> <path d fill> <button class="uds-tooltip"> <ol class> <drupal-media data-spacing-top data-spacing-bottom data-spacing-left data-spacing-right data-round title data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <img class src alt height width data-entity-uuid data-entity-type data-caption data-align> <ul class> <strong> <em> <a href title class id target data-entity-type data-entity-uuid data-entity-substitution role name hreflang> <li> <hr class="copy-divider"> <div class> <i class data-fa-transform> <span class data-fa-transform> <section class="simple-box"> <table> <tr rowspan colspan> <td rowspan colspan> <th rowspan colspan class="normal indent"> <thead> <tbody> <tfoot> <caption>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
@@ -97,3 +97,9 @@ filters:
     weight: -40
     settings:
       filter_url_length: 72
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -44
+    settings: {  }

--- a/web/profiles/webspark/webspark/config/install/filter.format.full_html.yml
+++ b/web/profiles/webspark/webspark/config/install/filter.format.full_html.yml
@@ -9,8 +9,6 @@ dependencies:
     - editor
     - linkit
     - media
-_core:
-  default_config_hash: PwHijPIQ1KW7KrMXy_TzSdLjozhXG7INtrEZ3dLRVVM
 name: 'Full HTML'
 format: full_html
 weight: 2
@@ -99,3 +97,9 @@ filters:
     weight: -42
     settings:
       filter_url_length: 72
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -44
+    settings: {  }

--- a/web/profiles/webspark/webspark/config/install/filter.format.minimal_format.yml
+++ b/web/profiles/webspark/webspark/config/install/filter.format.minimal_format.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Minimal Format'
+format: minimal_format
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<br> <p> <h2> <h3> <h4> <h5> <h6> <strong> <em> <a href title class id target="_blank">'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -354,24 +354,26 @@ function webspark_update_9018(&$sandbox) {
   $module_installer->install(["ckeditor5"]);
 }
 /**
- * WS2-1452 : Update the allowed HTML tags for the Basic HTML format.
+ * WS2-1452 & 1871: Update text formats; install editor_advanced_link; uninstall CKEditor4 and Fakeobjects.
  */
-function webspark_update_9019(&$sandbox) {
-  \Drupal::state()->set('configuration_locked', FALSE);
-  \Drupal::service('webspark.config_manager')->updateConfigFile('editor.editor.basic_html');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('editor.editor.full_html');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.basic_html');
-  \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.full_html');
-
-  \Drupal::state()->set('configuration_locked', TRUE);
-
-}
-
-/**
- * WS2-1871 : Uninstall FakeObjects module.
- */
-function webspark_update_9020(&$sandbox) {
+function webspark_update_10000(&$sandbox) {
   if (Drupal::moduleHandler()->moduleExists('fakeobjects')) {
     Drupal::service('module_installer')->uninstall(['fakeobjects']);
   }
+  if (Drupal::moduleHandler()->moduleExists('ckeditor')) {
+    Drupal::service('module_installer')->uninstall(['ckeditor']);
+  }
+  if (!Drupal::moduleHandler()->moduleExists('editor_advanced_link')) {
+    Drupal::service('module_installer')->install(['editor_advanced_link']);
+  }
+
+  \Drupal::state()->set('configuration_locked', FALSE);
+  \Drupal::service('webspark.config_manager')->updateConfigFile('editor.editor.basic_html');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('editor.editor.full_html');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('editor.editor.minimal_format');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.basic_html');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.full_html');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.minimal_format');
+  \Drupal::state()->set('configuration_locked', TRUE);
 }
+


### PR DESCRIPTION
### Description

Update text formats; install editor_advanced_link module; uninstall CKEditor4 and Fakeobjects modules.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1871)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

