### PR TITLE
WS2 release don't try to install color, quickedit, rdf

### DIFF
--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -13,7 +13,6 @@ install:
   - breakpoint
   - ckeditor
   - ckeditor5
-  - color
   - config
   - comment
   - contextual
@@ -21,7 +20,6 @@ install:
   - menu_link_content
   - datetime
   - block_content
-  - quickedit
   - editor
   - help
   - image
@@ -38,7 +36,6 @@ install:
   - toolbar
   - field_ui
   - file
-  - rdf
   - views
   - views_ui
   - automated_cron


### PR DESCRIPTION
### Description

Install process throws an error because color, quickedit and rdf are no longer in the codebase but included in the profile's .info.yml

Solution: remove them.