### PR TITLE
WS2-1867: Changed css selector in _drupal.scss from .page-wrapper-web-spark main to .page-wrapper-webspark:first-child

### DIFF
--- a/web/themes/webspark/renovation/src/sass/base/_drupal.scss
+++ b/web/themes/webspark/renovation/src/sass/base/_drupal.scss
@@ -29,7 +29,7 @@ body,
   height: 100%;
 }
 
-.page-wrapper-webspark main {
+.page-wrapper-webspark:first-child {
   @include media-breakpoint-down(md) {
     margin-top: 4px;
   }


### PR DESCRIPTION
### Description

#### Description of problem
Regression: Small space below header has returned
#### Solution
Changed css selector in _drupal.scss from '.page-wrapper-web-spark main' to '.page-wrapper-webspark:first-child'

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1867)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
