### PR TITLE
WS2-1907: Fontawesome icons are doubled up in the icon picker widget. Needs fix.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c55389407d4253c8cc0f16e58fde13c",
+    "content-hash": "4f1d7c178ca47644230e9a616d7d3162",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3502,29 +3502,26 @@
         },
         {
             "name": "drupal/fontawesome",
-            "version": "2.26.0",
+            "version": "dev-2.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/fontawesome.git",
-                "reference": "8.x-2.26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/fontawesome-8.x-2.26.zip",
-                "reference": "8.x-2.26",
-                "shasum": "22e67458e1ebc274c3a8b494ce2c4056a3d2af29"
+                "reference": "65e140fe9124b65ef7862e266fddf50382580264"
             },
             "require": {
                 "drupal/core": "^9.4 || ^10"
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
-                    "version": "8.x-2.26",
-                    "datestamp": "1688063477",
+                    "version": "8.x-2.26+6-dev",
+                    "datestamp": "1694619484",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
                     }
                 },
                 "drush": {
@@ -6418,7 +6415,7 @@
             "dist": {
                 "type": "path",
                 "url": "upstream-configuration",
-                "reference": "880445bffbcdb9a8d24a1d2e84c4aff5d1e7e94e"
+                "reference": "a857cb23c6e9d3de5608421f1f911bf123191d74"
             },
             "require": {
                 "composer/installers": "v2.0.0",
@@ -6449,7 +6446,7 @@
                 "drupal/field_group": "3.4.0",
                 "drupal/field_menu": "2.1.0",
                 "drupal/field_states_ui": "3.0",
-                "drupal/fontawesome": "2.26.0",
+                "drupal/fontawesome": "2.x-dev@dev",
                 "drupal/image_widget_crop": "2.4.0",
                 "drupal/imagemagick": "3.6.0",
                 "drupal/layout_builder_component_attributes": "2.1.1",
@@ -12630,16 +12627,16 @@
         },
         {
             "name": "open-telemetry/sdk",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "a827f2544cfcd65eb39bf26bc0c4a0978de426e6"
+                "reference": "818263750d299df5b9612a738440e56d92e5a296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/a827f2544cfcd65eb39bf26bc0c4a0978de426e6",
-                "reference": "a827f2544cfcd65eb39bf26bc0c4a0978de426e6",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/818263750d299df5b9612a738440e56d92e5a296",
+                "reference": "818263750d299df5b9612a738440e56d92e5a296",
                 "shasum": ""
             },
             "require": {
@@ -12709,20 +12706,20 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2024-01-16T21:54:57+00:00"
+            "time": "2024-01-24T12:00:22+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
-            "version": "1.23.1",
+            "version": "1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "6921f9450510bf8e87c737f731ff818de05bf9c4"
+                "reference": "d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/6921f9450510bf8e87c737f731ff818de05bf9c4",
-                "reference": "6921f9450510bf8e87c737f731ff818de05bf9c4",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3",
+                "reference": "d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3",
                 "shasum": ""
             },
             "require": {
@@ -12766,7 +12763,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2023-11-21T22:12:22+00:00"
+            "time": "2024-01-23T21:47:17+00:00"
         },
         {
             "name": "palantirnet/drupal-rector",
@@ -13588,16 +13585,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.56",
+            "version": "1.10.57",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "27816a01aea996191ee14d010f325434c0ee76fa"
+                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/27816a01aea996191ee14d010f325434c0ee76fa",
-                "reference": "27816a01aea996191ee14d010f325434c0ee76fa",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
                 "shasum": ""
             },
             "require": {
@@ -13646,7 +13643,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-15T10:43:00+00:00"
+            "time": "2024-01-24T11:51:34+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -27,7 +27,7 @@
         "drupal/field_group": "3.4.0",
         "drupal/field_menu": "2.1.0",
         "drupal/field_states_ui": "3.0",
-        "drupal/fontawesome": "2.26.0",
+        "drupal/fontawesome": "2.x-dev@dev",
         "drupal/image_widget_crop": "2.4.0",
         "drupal/imagemagick": "3.6.0",
         "drupal/layout_builder_component_attributes": "2.1.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -27,7 +27,7 @@
         "drupal/field_group": "3.4.0",
         "drupal/field_menu": "2.1.0",
         "drupal/field_states_ui": "3.0",
-        "drupal/fontawesome": "2.x-dev@dev",
+        "drupal/fontawesome": "2.x-dev#65e140f",
         "drupal/image_widget_crop": "2.4.0",
         "drupal/imagemagick": "3.6.0",
         "drupal/layout_builder_component_attributes": "2.1.1",

--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -14,7 +14,8 @@
     },
     "drupal/fontawesome": {
         "#3274028: Fixing CKEditor 5 compatibility": "https://www.drupal.org/files/issues/2024-01-17/ckeditor_compatibility_issue_0.patch",
-        "#3274028: Fixing CKEditor 5 inline Icons": "https://www.drupal.org/files/issues/2024-01-16/fix_inline_icons_0.patch"
+        "#3274028: Fixing CKEditor 5 inline Icons": "https://www.drupal.org/files/issues/2024-01-16/fix_inline_icons_0.patch",
+        "3417901: Breaking change introduced in a38b572": "https://www.drupal.org/files/issues/2024-01-29/fontawesome-prefixbug-3417901-1.patch"
     },
     "drupal/cas": {
         "3318382: TypeError: in_array(): Argument #2 ($haystack) must be of type array": "https://www.drupal.org/files/issues/2022-10-31/cas-null-in_array-3318382-0.patch"


### PR DESCRIPTION
### Description

I have created a fix and submitted it to Drupal.org. It builds off of the dev branch. In order to keep our site as stable as possible while on the dev branch, I have chosen to pin us to a specific commit, which is the current top commit of that branch. If more commits are made, Composer will ignore them. This will keep us stable until we can vet the new commits and eventually update to a stable version of the module.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1907)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
