### PR TITLE
WS2-1891: Added .install in webspark_module_renovation_layout to install layout_builder_usage_reports

### DIFF
--- a/web/modules/webspark/webspark_module_renovation_layouts/webspark_module_renovacion_layouts.install
+++ b/web/modules/webspark/webspark_module_renovation_layouts/webspark_module_renovacion_layouts.install
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Install Layout builder report module
+ */
+function webspark_module_renovacion_layouts_update_9001(&$sandbox): void {
+  if (!Drupal::moduleHandler()->moduleExists('layout_builder_usage_reports')) {
+    Drupal::service('module_installer')->install(['layout_builder_usage_reports']);
+  }
+}


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Added new .install to install layout_builder_usage_reports module

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1891)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
