### PR TITLE
add hook_update to remove unwanted layouts

### DIFF
--- a/web/profiles/webspark/webspark/config/install/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/webspark/webspark/config/install/core.entity_view_display.node.page.default.yml
@@ -13,8 +13,8 @@ dependencies:
     - webspark_module_renovation_layouts
 third_party_settings:
   layout_builder:
-    allow_custom: true
     enabled: true
+    allow_custom: true
     sections:
       -
         layout_id: onecol_full_width_section
@@ -33,71 +33,72 @@ third_party_settings:
             configuration:
               id: 'field_block:node:page:title'
               label: Title
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: hidden
-                type: string
-                settings:
-                  link_to_entity: false
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
             weight: 0
             additional: {  }
           de05504e-2a2d-4f37-a27e-fdcfca9c470e:
             uuid: de05504e-2a2d-4f37-a27e-fdcfca9c470e
             region: first
             configuration:
+              id: 'field_block:node:page:body'
               label_display: '0'
               context_mapping:
                 entity: layout_builder.entity
-              id: 'field_block:node:page:body'
               formatter:
+                type: text_default
                 label: above
                 settings: {  }
                 third_party_settings: {  }
-                type: text_default
             weight: 1
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
-      whitelisted_blocks:
-        'Content fields': {  }
-        System: {  }
-        core: {  }
-      blacklisted_blocks:
+      allowed_layouts:
+        - onecol_full_width_section
+        - onecol_fixed_width_section
+        - layout_twocol_bootstrap_section
+        - threecol_fixed_width_section
+        - fourcol_fixed_width_section
+      denylisted_blocks:
         'ASU brand':
           - asu_brand_header
         'ASU footer':
           - asu_footer
         'Custom blocks':
           - webspark_blocks_back_to_top
-      allowed_layouts:
-        - layout_twocol_bootstrap_section
-        - onecol_full_width_section
-        - onecol_fixed_width_section
-        - threecol_fixed_width_section
-        - fourcol_fixed_width_section
+      allowlisted_blocks:
+        'Content fields': {  }
+        System: {  }
+        core: {  }
+      restricted_categories: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page
 mode: default
 content:
   body:
-    weight: 102
+    type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 102
     region: first
   links:
-    weight: 101
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 101
+    region: content
 hidden:
   layout_builder__layout: true

--- a/web/profiles/webspark/webspark/config/install/core.entity_view_display.node.page.default.yml
+++ b/web/profiles/webspark/webspark/config/install/core.entity_view_display.node.page.default.yml
@@ -78,11 +78,7 @@ third_party_settings:
           - asu_footer
         'Custom blocks':
           - webspark_blocks_back_to_top
-      allowlisted_blocks:
-        'Content fields': {  }
-        System: {  }
-        core: {  }
-      restricted_categories: {  }
+      allowlisted_blocks: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -354,7 +354,7 @@ function webspark_update_9018(&$sandbox) {
   $module_installer->install(["ckeditor5"]);
 }
 /**
- * WS2-1452 & 1871: Update text formats; install editor_advanced_link; uninstall CKEditor4 and Fakeobjects.
+ * WS2-1452, 1871 & 1915: Update layouts and text formats; install editor_advanced_link; uninstall CKEditor4 and Fakeobjects.
  */
 function webspark_update_10000(&$sandbox) {
   if (Drupal::moduleHandler()->moduleExists('fakeobjects')) {
@@ -374,6 +374,7 @@ function webspark_update_10000(&$sandbox) {
   \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.basic_html');
   \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.full_html');
   \Drupal::service('webspark.config_manager')->updateConfigFile('filter.format.minimal_format');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_view_display.node.page.default');
   \Drupal::state()->set('configuration_locked', TRUE);
 }
 


### PR DESCRIPTION
It looks like the yaml file just has stuff moved around. I figured I'd update it just in case there were any other things D10 changed. So, really, the only change in this PR is in the `.install` file's hooks. Pretty straightforward.

P.S. Since Dev already has run `hook_update_10000` this won't change anything in the CI build. But, when people apply the updates for the first time, it will take effect. A quick QA check would be to run:
`terminus drush webspark-ci.pr-301 -- ev "\Drupal::service('update.update_hook_registry')->setInstalledVersion('webspark', 9018)"; terminus drush webspark-ci.pr-301 -- updb` which should run the hook.

P.P.S. I have run the above terminus commands in the PR multidev. It's easy to test this by opening a Basic Page (like the Accordion page) and attempting to add a new section.