### PR TITLE
WS2-1921: Added new classes for ckeditor buttons used into tab content

### DIFF
--- a/web/themes/webspark/renovation/src/sass/helpers/_ckeditor.scss
+++ b/web/themes/webspark/renovation/src/sass/helpers/_ckeditor.scss
@@ -75,3 +75,15 @@ hr.copy-divider {
   background-color: #ffc627 !important;
   max-width: 16rem !important;
 }
+
+a.btn-gold, a.btn-gray {
+  span{
+    color: $uds-color-font-dark-base !important;
+  }
+}
+
+a.btn-maroon, a.btn-dark {
+  span{
+    color: $uds-color-font-light-base !important;
+  }
+}


### PR DESCRIPTION
### Description
The button text color is off while using the ckeditor in tabbed content. 
<!-- Description of problem -->
#### Solution
Added new classes for ckeditor buttons used into tab content

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1921)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
