### PR TITLE
WS2-1888 - Fix webspark blocks 404 settings and related links display

### DIFF
--- a/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
+++ b/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
@@ -58,6 +58,7 @@ class WebsparkBlocksAdminSettings extends ConfigFormBase {
     $form['links_fieldset'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('404 Links'),
+      '#markup' => '<p>When adding links, both the url and title are required.</p>',
       '#prefix' => '<div id="names-fieldset-wrapper">',
       '#suffix' => '</div>',
     ];
@@ -70,12 +71,22 @@ class WebsparkBlocksAdminSettings extends ConfigFormBase {
       $form['links_fieldset']['link_fieldset'. $i]['link_url'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Url'),
-        '#default_value' => $links[$i]['link_url'],
+        '#default_value' => isset($links[$i]['link_url']) ? $links[$i]['link_url'] : '',
+        '#states' => [
+          'required' => [
+            ':input[name="links_fieldset[link_fieldset'. $i .'][link_title]"]' => ['filled' => TRUE],
+          ],
+        ]
       ];
       $form['links_fieldset']['link_fieldset'. $i]['link_title'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Link Title'),
-        '#default_value' => $links[$i]['link_title'],
+        '#default_value' => isset($links[$i]['link_title']) ? $links[$i]['link_title'] : '',
+        '#states' => [
+          'required' => [
+            ':input[name="links_fieldset[link_fieldset'. $i .'][link_url]"]' => ['filled' => TRUE],
+          ],
+        ]
       ];
 
     }

--- a/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
+++ b/web/modules/webspark/webspark_blocks/src/Form/WebsparkBlocksAdminSettings.php
@@ -58,7 +58,7 @@ class WebsparkBlocksAdminSettings extends ConfigFormBase {
     $form['links_fieldset'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('404 Links'),
-      '#markup' => '<p>When adding links, both the url and title are required.</p>',
+      '#markup' => t('When adding links, both the url and title are required.'),
       '#prefix' => '<div id="names-fieldset-wrapper">',
       '#suffix' => '</div>',
     ];

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.module
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.module
@@ -155,16 +155,30 @@ function _webspark_blocks_preprocess_page_404(&$variables) {
   ];
 
 
-  // Get the links.
+  // Get the links, if they exist
   $config = \Drupal::config('webspark_blocks.settings');
   $links = $config->get('webspark_utility_links');
-  $wrapper['links'] = [
-    '#theme' => 'webspark_blocks__links',
-    '#title' => t('Here are some links you may find helpful'),
-    '#links' => $links,
-  ];
+
+  // loop through $links to find any non-empty values
+  // if we find any, we'll display the links  
+  // if we don't find any, we'll skip displaying the links
+  
+  foreach ($links as $link) {
+    if (!empty($link['link_url']) && !empty($link['link_title'])) {
+      $has_links = TRUE;
+        if ($has_links) {
+          $wrapper['links'] = [
+            '#theme' => 'webspark_blocks__links',
+            '#title' => t('Here are some links you may find helpful'),
+            '#links' => $links,
+          ];
+        }
+      break;
+    }
+  }
 
   $variables['page']['content']['page_404_content'] = $wrapper;
+  
 }
 
 /**


### PR DESCRIPTION
### Description

Webspark blocks admin pageview throws error in watchdog logs.

Second fix for this ticket -- add checks for default settings for links, makes both fields require each other before saving (field states) and checks if there are any links before displaying related links title.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1888)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox

