### PR TITLE
allow jstree through style fence

### DIFF
--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddPeopleWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddPeopleWidget.php
@@ -29,7 +29,7 @@ class WebdirAddPeopleWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-add-people')),
-      '#prefix' => '<div id="asurite-add-people-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="asurite-add-people-options" style="width: 100%" class="ck-reset"></div>',
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddWidget.php
@@ -29,7 +29,7 @@ class WebdirAddWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-add')),
-      '#prefix' => '<div id="asurite-add-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="asurite-add-options" style="width: 100%" class="ck-reset"></div>',
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAsuriteWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAsuriteWidget.php
@@ -29,7 +29,7 @@ class WebdirAsuriteWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-tree')),
-      '#prefix' => '<div id="asurite-tree-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="asurite-tree-options" style="width: 100%" class="ck-reset"></div>',
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirCampusWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirCampusWidget.php
@@ -29,9 +29,9 @@ class WebdirCampusWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('campus-tree')),
-      '#prefix' => '<div id="campus-tree-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="campus-tree-options" style="width: 100%" class="ck-reset"></div>',
     ];
-    
+
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';
     $element['#attached']['library'][] = 'webspark_webdir/campus_field';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirDepartmentsWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirDepartmentsWidget.php
@@ -29,7 +29,7 @@ class WebdirDepartmentsWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('directory-tree')),
-      '#prefix' => '<div id="directory-tree-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="directory-tree-options" style="width: 100%" class="ck-reset"></div>',
     ];
 
     // Add the required libraries.

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirEmployeeTypeWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirEmployeeTypeWidget.php
@@ -29,9 +29,9 @@ class WebdirEmployeeTypeWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('employee-type-tree')),
-      '#prefix' => '<div id="employee-type-tree-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="employee-type-tree-options" style="width: 100%" class="ck-reset"></div>',
     ];
-    
+
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';
     $element['#attached']['library'][] = 'webspark_webdir/employee_type_field';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirExpertiseWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirExpertiseWidget.php
@@ -29,9 +29,9 @@ class WebdirExpertiseWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('expertise-tree')),
-      '#prefix' => '<div id="expertise-tree-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="expertise-tree-options" style="width: 100%" class="ck-reset"></div>',
     ];
-    
+
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';
     $element['#attached']['library'][] = 'webspark_webdir/expertise_field';
@@ -41,7 +41,7 @@ class WebdirExpertiseWidget extends WidgetBase {
       '#attributes' => array('class' => array('container-inline')),
       '#open' => FALSE,
     );
-    
+
     return $element;
   }
 }

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirListWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirListWidget.php
@@ -29,7 +29,7 @@ class WebdirListWidget extends WidgetBase {
       '#type' => 'hidden',
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-list')),
-      '#prefix' => '<div id="asurite-list-options" style="width: 100%"></div>',
+      '#prefix' => '<div id="asurite-list-options" style="width: 100%" class="ck-reset"></div>',
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';


### PR DESCRIPTION
Adding the class `.ck-reset` allows items through the style fence.

Testing steps:
- Go to `/node/31/layout`
- Click the pencil icon to load the "off canvas" dialog for each web directory block
- Make sure that there are checkboxes and collapsible triangles in the "Departments," "Filter by campus," "Filter by expertise areas," and "Filter by employee type" collapsibles
- Make sure that names in the "add profiles" section have collapsible triangles
- Make sure that the names in the "Profiles" section have multi-directional arrows and can be drag-dropped
- Make sure that none of these have list item bullets. They should be "bullet-less"

If all of these things are the case, it passes.