### PR TITLE
add hook to remove 'node_type' in configs

### DIFF
--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -330,8 +330,6 @@ function webspark_update_9015(&$sandbox) {
   \Drupal::state()->set('configuration_locked', TRUE);
 }
 
-
-
 /**
  * Update the settings of the FontAwesome module to work with ASUAwesome better.
  */
@@ -353,6 +351,69 @@ function webspark_update_9018(&$sandbox) {
 
   $module_installer->install(["ckeditor5"]);
 }
+
+/**
+ * Convert 'node_type' to 'entity_bundle:node' in configurations
+ */
+function webspark_update_9019(&$sandbox) {
+  $db = \Drupal::database();
+  $query = $db->select('config', 'c')->fields('c', ['name', 'data'])->condition('data', '%' . $db->escapeLike('node_type') . '%', "LIKE");
+  $results = $query->execute()->fetchAll();
+  $new_results = [];
+  // Convert node_type to entity_bundle:node and add result to $new_results.
+  foreach ($results as $result) {
+    $fixUp = _fix_serialized(str_replace('node_type', 'entity_bundle:node', $result->data));
+    $new_results[$result->name] = ['name'=> $result->name, 'data' => $fixUp];
+  }
+  foreach ($new_results as $nr) {
+    $decoded = unserialize($nr['data'], ['allowed_classes' => TRUE]);
+    try {
+      /** @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory */
+      $configFactory = \Drupal::service('config.factory');
+      $config = $configFactory->getEditable($nr['name']);
+      $config->setData($decoded)->save();
+    } catch (\Exception $e) {
+      \Drupal::logger('webspark')->error($e->getMessage());
+    }
+  }
+}
+
+/**
+ * Fixes the length of the given string and returns the fixed length string representation.
+ *
+ * Borrowed from https://gist.github.com/chlp/8dac656c562941308d4621fd61856e22
+ *
+ * @param array $matches The array of matches from the regular expression
+ * @return string The fixed length string representation
+ */
+function _fix_str_length($matches): string {
+  $string = $matches[2];
+  $right_length = strlen($string); // yes, strlen even for UTF-8 characters, PHP wants the mem size, not the char count
+  return 's:' . $right_length . ':"' . $string . '";';
+}
+/**
+ * Fix serialized data for security and compatibility.
+ *
+ * Borrowed from https://gist.github.com/chlp/8dac656c562941308d4621fd61856e22
+ *
+ * @param string $string The serialized data to be fixed.
+ * @return string The fixed serialized data.
+ */
+function _fix_serialized($string): string {
+  // securities
+  if ( !preg_match('/^[aOs]:/', $string) ) return $string;
+  if ( unserialize($string, ['allowed_classes' => true]) !== false ) return $string;
+  $string = preg_replace("%\n%", "", $string);
+  // doublequote exploding
+  $data = preg_replace('%";%', "µµµ", $string);
+  $tab = explode("µµµ", $data);
+  $new_data = '';
+  foreach ($tab as $line) {
+    $new_data .= preg_replace_callback('%\bs:(\d+):"(.*)%', '_fix_str_length', $line);
+  }
+  return $new_data;
+}
+
 /**
  * WS2-1452, 1871 & 1915: Update layouts and text formats; install editor_advanced_link; uninstall CKEditor4 and Fakeobjects.
  */


### PR DESCRIPTION
This is a tough one to test. My approach has been to hopefully do the find-replace before any of the other Drupal 10 configs get changed. I have been able to verify the functionality by copy and pasting the code I added here into existing Drupal 9 sites that are on WS 2.11.1. To check that it is working, I spun up the site, and then exported the configs (with `ddev drush cex`) and committed them temporarily to git, so that I could see future changes. Then I ran `ddev drush updb` and after the update finished, I ran `ddev drush cex` again. This allowed me to easily see if any config files had been changed. I then verified visually within a few of the files to see if they had been created properly. I also did a search within the `config` directory in my IDE to see if there were any instances of `node_type` in the YAML files. Nothing got returned, so I think this is working as expected. Feel free to test it similar to how I did. 

I tested it on the `asu-search`, `asuwatts`, and `ws-test-2-11` sites. All three sites seemed to work without issue. I did realize that I forgot to check the watchdog log for any errors that may have been caught in the `try ... catch` code. But, other than that, I think I tested it pretty thoroughly. 