### PR TITLE
WS2-1939 fix circular dependency issue using webspark_utilities

### DIFF
--- a/web/modules/webspark/webspark_blocks/webspark_blocks.info.yml
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - drupal:paragraphs
   - drupal:media
   - drupal:media_library
-  - asuwebplatforms:webspark_utility
+  - webspark_utility
   - drupal:fontawesome
   - drupal:fontawesome_iconpicker_widget
   - drupal:responsive_image
@@ -22,3 +22,4 @@ dependencies:
   - drupal:allowed_formats
   - drupal:crop
   - drupal:block_field
+  - drupal:filter

--- a/web/modules/webspark/webspark_utility/config/install/filter.format.basic_html.yml
+++ b/web/modules/webspark/webspark_utility/config/install/filter.format.basic_html.yml
@@ -1,0 +1,97 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Basic HTML'
+format: basic_html
+weight: 0
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: -45
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -48
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -41
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: -47
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -50
+    settings:
+      allowed_html: '<br> <p class="lead"> <h1> <h2 id> <h3 id> <h4 id> <h5 id> <dl> <dt> <dd> <mark> <cite class> <blockquote cite class> <svg title role viewbox class> <path d fill> <button class="uds-tooltip"> <ol class> <drupal-media data-spacing-top data-spacing-bottom data-spacing-left data-spacing-right data-round title data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <img class src alt height width data-entity-uuid data-entity-type data-caption data-align> <ul class> <strong> <em> <a href title class id target data-entity-type data-entity-uuid data-entity-substitution role name hreflang> <li> <hr class="copy-divider"> <div class> <i class data-fa-transform> <span class data-fa-transform> <section class="simple-box"> <table> <tr rowspan colspan> <td rowspan colspan> <th rowspan colspan class="normal indent"> <thead> <tbody> <tfoot> <caption>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: -46
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -44
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -40
+    settings:
+      filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -49
+    settings:
+      title: true
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: -44
+    settings:
+      default_view_mode: default
+      allowed_view_modes:
+        default: default
+        large: large
+        medium: medium
+        small: small
+      allowed_media_types:
+        cropped_image_sqare: cropped_image_sqare
+        cropped_image_wide: cropped_image_wide
+        document: document
+        image: image
+        image_block_images: image_block_images
+        remote_video: remote_video

--- a/web/modules/webspark/webspark_utility/config/install/filter.format.full_html.yml
+++ b/web/modules/webspark/webspark_utility/config/install/filter.format.full_html.yml
@@ -1,0 +1,97 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Full HTML'
+format: full_html
+weight: 2
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: -45
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -47
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: -48
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -50
+    settings:
+      allowed_html: ''
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: -41
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -46
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -44
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -42
+    settings:
+      filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -49
+    settings:
+      title: true
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: -40
+    settings:
+      default_view_mode: default
+      allowed_view_modes:
+        default: default
+        large: large
+        medium: medium
+        small: small
+      allowed_media_types:
+        cropped_image_sqare: cropped_image_sqare
+        cropped_image_wide: cropped_image_wide
+        document: document
+        image: image
+        image_block_images: image_block_images
+        remote_video: remote_video

--- a/web/modules/webspark/webspark_utility/config/install/filter.format.restricted_html.yml
+++ b/web/modules/webspark/webspark_utility/config/install/filter.format.restricted_html.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Restricted HTML'
+format: restricted_html
+weight: 1
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72
+


### PR DESCRIPTION
### Description

New site creation was running into missing dependencies errors from paragraph fields for ranking cards when `webspark_blocks` tried to load. We can't include those ymls in `webspark_blocks` because they're in the profile and also that would make the config readonly. Additionally, we can't declare the profile as a dependency, because the profile depends on `webspark_blocks`. Circularity!

Solution: I sanitized the needed filter.format.*.yml files of additional dependencies, and put them into `webspark_utilities` which is declared as a dependency in `webspark_blocks`. That dependency needed to be cleaned up since we no longer pull the module in using Composer, and then I also added a dependency on the drupal:filter module. Now, those formats get pulled in an satisfied for `webspark_blocks` and then fully loaded in with dependencies when profile configs are read in. Long term solution to be sought via WS2-1936

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1939)

### Testing

Install a new site. It should install without error. Then visit the input format page for the Full HTML input format. The "View modes selectable in the 'Edit media' dialog" section should have Small, Medium and Large checked (the dependencies). That confirms that ultimately, the correct settings are in place.