### PR TITLE
WS2-1983: applying a patch to add content after injecting the grid.

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -26,5 +26,8 @@
     },
     "drupal/paragraphs": {
         "#3090200: Paragraphs do not render: access check for view fail when using layout builder": "https://www.drupal.org/files/issues/2022-10-26/3084934-13_combine_3090200-22.patch"
+    },
+    "drupal/ckeditor_responsive_plugin": {
+        "#3334636 : Add content after injecting the grid ": "https://www.drupal.org/files/issues/2023-08-22/ckeditor_responsive_plugin_2-1.patch"
     }
 }

--- a/web/modules/webspark/webspark_ckeditor_plugins/webspark_ckeditor_plugins.ckeditor5.yml
+++ b/web/modules/webspark/webspark_ckeditor_plugins/webspark_ckeditor_plugins.ckeditor5.yml
@@ -96,7 +96,6 @@ webspark_ckeditor_plugins_plugins:
       - <p class="lead">
       - <div class="uds-table">
       - <div class="uds-table uds-table-fixed">
-      - <div class>
       - <table>
       - <tr>
       - <td>

--- a/web/modules/webspark/webspark_ckeditor_plugins/webspark_ckeditor_plugins.install
+++ b/web/modules/webspark/webspark_ckeditor_plugins/webspark_ckeditor_plugins.install
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the Webspark CKeditor plugins module.
+ */
+
+/**
+* Implements hook_update() on WS2-1983.
+*/
+function webspark_ckeditor_plugins_update_10001(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  $config_factory = \Drupal::service('config.factory');
+  $editor_configs = $config_factory->listAll($prefix = 'editor.editor');
+  $editor_configs = [...$editor_configs, ...$config_factory->listAll($prefix = 'filter.format')];
+  foreach ($editor_configs as $value) {
+    $config = \Drupal::config($value);
+    if ($config) {
+      $data = $config->getRawData();
+      if ($data && isset($data['settings']['plugins']['ckeditor5_heading']['enabled_headings'])) {
+        $allowed_tags = $data['settings']['plugins']['ckeditor5_sourceEditing']['allowed_tags'];
+        if ($allowed_tags) {
+          $div_class = array_search('<div class>', $allowed_tags);
+          if ($div_class === false) {
+            array_push($allowed_tags, '<div class>');
+            $config_editable = $config_factory->getEditable($value);
+            $config_editable->set('settings.plugins.ckeditor5_sourceEditing.allowed_tags', $allowed_tags);
+            $config_editable->save();
+            \Drupal::service('messenger')
+              ->addMessage("CK Editor - Modified Source Editing for " . $config->getName());
+          }
+        }
+      }
+    }
+  }
+  \Drupal::state()->set('configuration_locked', TRUE);
+}
+

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -447,34 +447,3 @@ function webspark_update_10001(&$sandbox) {
     Drupal::service('module_installer')->install(['layout_builder_usage_reports']);
   }
 }
-
-/**
-* Implements hook_update() on WS2-1983.
-*/
-function webspark_update_10002(&$sandbox) {
-  \Drupal::state()->set('configuration_locked', FALSE);
-  $config_factory = \Drupal::service('config.factory');
-  $editor_configs = $config_factory->listAll($prefix = 'editor.editor');
-  $editor_configs = [...$editor_configs, ...$config_factory->listAll($prefix = 'filter.format')];
-  foreach ($editor_configs as $value) {
-    $config = \Drupal::config($value);
-    if ($config) {
-      $data = $config->getRawData();
-      if ($data && isset($data['settings']['plugins']['ckeditor5_heading']['enabled_headings'])) {
-        $allowed_tags = $data['settings']['plugins']['ckeditor5_sourceEditing']['allowed_tags'];
-        if ($allowed_tags) {
-          $div_class = array_search('<div class>', $allowed_tags);
-          if ($div_class === false) {
-            array_push($allowed_tags, '<div class>');
-            $config_editable = $config_factory->getEditable($value);
-            $config_editable->set('settings.plugins.ckeditor5_sourceEditing.allowed_tags', $allowed_tags);
-            $config_editable->save();
-            \Drupal::service('messenger')
-              ->addMessage("CK Editor - Modified Source Editing for " . $config->getName());
-          }
-        }
-      }
-    }
-  }
-  \Drupal::state()->set('configuration_locked', TRUE);
-}

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -447,3 +447,34 @@ function webspark_update_10001(&$sandbox) {
     Drupal::service('module_installer')->install(['layout_builder_usage_reports']);
   }
 }
+
+/**
+* Implements hook_update() on WS2-1983.
+*/
+function webspark_update_10002(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  $config_factory = \Drupal::service('config.factory');
+  $editor_configs = $config_factory->listAll($prefix = 'editor.editor');
+  $editor_configs = [...$editor_configs, ...$config_factory->listAll($prefix = 'filter.format')];
+  foreach ($editor_configs as $value) {
+    $config = \Drupal::config($value);
+    if ($config) {
+      $data = $config->getRawData();
+      if ($data && isset($data['settings']['plugins']['ckeditor5_heading']['enabled_headings'])) {
+        $allowed_tags = $data['settings']['plugins']['ckeditor5_sourceEditing']['allowed_tags'];
+        if ($allowed_tags) {
+          $div_class = array_search('<div class>', $allowed_tags);
+          if ($div_class === false) {
+            array_push($allowed_tags, '<div class>');
+            $config_editable = $config_factory->getEditable($value);
+            $config_editable->set('settings.plugins.ckeditor5_sourceEditing.allowed_tags', $allowed_tags);
+            $config_editable->save();
+            \Drupal::service('messenger')
+              ->addMessage("CK Editor - Modified Source Editing for " . $config->getName());
+          }
+        }
+      }
+    }
+  }
+  \Drupal::state()->set('configuration_locked', TRUE);
+}


### PR DESCRIPTION
### Description

This patch solved the content adding after injecting the element, but it's not resolving the switching between FULL & BASIC HTML. Also, it strip the classes when clicking on Source and edit the content.
It's a quick solution that could give us sometime.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-0000)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
