### PR TITLE
WS2-1984 update uds theme to 1.9.6 for mixed lists fix

### DIFF
--- a/web/themes/webspark/renovation/package.json
+++ b/web/themes/webspark/renovation/package.json
@@ -21,7 +21,7 @@
         "sass-loader": "^12.1.0"
     },
     "dependencies": {
-        "@asu/unity-bootstrap-theme": "1.9.6",
+        "@asu/unity-bootstrap-theme": "1.9.7",
         "@popperjs/core": "^2.11.8"
     }
 }

--- a/web/themes/webspark/renovation/package.json
+++ b/web/themes/webspark/renovation/package.json
@@ -21,7 +21,7 @@
         "sass-loader": "^12.1.0"
     },
     "dependencies": {
-        "@asu/unity-bootstrap-theme": "1.9.1",
+        "@asu/unity-bootstrap-theme": "1.9.6",
         "@popperjs/core": "^2.11.8"
     }
 }

--- a/web/themes/webspark/renovation/yarn.lock
+++ b/web/themes/webspark/renovation/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@asu/unity-bootstrap-theme@1.9.1":
-  version "1.9.1"
-  resolved "https://npm.pkg.github.com/download/@asu/unity-bootstrap-theme/1.9.1/bc73256504de32be0d4fb2371c1ac3f2fdf9ba4c#bc73256504de32be0d4fb2371c1ac3f2fdf9ba4c"
-  integrity sha512-CE//MI3q8DhkY5gACOtcilDvR/AWh9vZHAmoDdfv7wSZ6jqwI5QUMo/H0kSi/lqT75DcbmAV5WfHSLICbu5WcA==
+"@asu/unity-bootstrap-theme@1.9.6":
+  version "1.9.6"
+  resolved "https://npm.pkg.github.com/download/@asu/unity-bootstrap-theme/1.9.6/ff59123eb3443a7e3024582225c44e30f518a865#ff59123eb3443a7e3024582225c44e30f518a865"
+  integrity sha512-e+JpsSSjOGowPOdZeSCLGAe7fES/y3Ix1vhUMG+taXMnXXsD1WSA3XOWRKe3unn+ZPAX/GLCPyqH+uutxXlOfg==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.22.5":
   version "7.22.10"

--- a/web/themes/webspark/renovation/yarn.lock
+++ b/web/themes/webspark/renovation/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@asu/unity-bootstrap-theme@1.9.6":
-  version "1.9.6"
-  resolved "https://npm.pkg.github.com/download/@asu/unity-bootstrap-theme/1.9.6/ff59123eb3443a7e3024582225c44e30f518a865#ff59123eb3443a7e3024582225c44e30f518a865"
-  integrity sha512-e+JpsSSjOGowPOdZeSCLGAe7fES/y3Ix1vhUMG+taXMnXXsD1WSA3XOWRKe3unn+ZPAX/GLCPyqH+uutxXlOfg==
+"@asu/unity-bootstrap-theme@1.9.7":
+  version "1.9.7"
+  resolved "https://npm.pkg.github.com/download/@asu/unity-bootstrap-theme/1.9.7/c3e2d7e05fc70be6243094bd0c0a76c25bb4c8b3#c3e2d7e05fc70be6243094bd0c0a76c25bb4c8b3"
+  integrity sha512-Sgx9x9x1Dg5xNjWKFy9FRYFIM9k/1kbeonyPeyG7DQ39A8YYTHr1DwnZ4QVS1pq9vBL8bBlbNFQppLMgMQjHyA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.22.5":
   version "7.22.10"


### PR DESCRIPTION
Fix mixed lists styles by updating to latest theme.

We need to verify that Accordions, card padding and endorsed logos in footer aren't negatively impacted - details on https://asudev.jira.com/browse/WS2-1984?focusedCommentId=1951183 (these are fixes from the intermediate releases and in some cases may require additional development in WS2 to accommodate them).