### PR TITLE
WS2-1656: Background Colors - Some components do not have default background colors

### DIFF
--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
@@ -11,7 +11,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
 {%
     set container_classes = [
     'clearfix',

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
@@ -11,7 +11,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
 {%
     set container_classes = [
     'clearfix',

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/fourcol_fixed_width_section/fourcol-fixed-width-section.html.twig
@@ -9,9 +9,14 @@
  * panel of the layout. This layout supports the following sections:
  */
 #}
+{% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
 {%
     set container_classes = [
-    'clearfix'
+    'clearfix',
+    bgcolor,
+    unpublished,
 ]
 %}
 {% if classes %}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
@@ -1,5 +1,9 @@
 {% if content %}
-  <div{{ attributes.addClass('layout__full-width') }}>
+  {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+  {% set bg = settings['additional']['classes']['style'] %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+
+  <div{{ attributes.addClass('layout__full-width,' bgcolor, unpublished) }}>
     {% if content.first %}
       <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
         {{ content.first }}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
@@ -1,7 +1,7 @@
 {% if content %}
   {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
 
   <div{{ attributes.addClass('layout__full-width,' bgcolor, unpublished) }}>
     {% if content.first %}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_article_hero_section/onecol-article-hero-section.html.twig
@@ -1,8 +1,7 @@
 {% if content %}
   {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
-
+  {% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
   <div{{ attributes.addClass('layout__full-width,' bgcolor, unpublished) }}>
     {% if content.first %}
       <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
@@ -1,7 +1,10 @@
 {% if content %}
+  {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+  {% set bg = settings['additional']['classes']['style'] %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
   <div class="layout__fixed-width">
     {% if content.first %}
-      <div {{ attributes.addClass('max-size-container','center-container') }}>
+      <div {{ attributes.addClass('max-size-container','center-container', bgcolor, unpublished) }}>
         <div class="container">
           <div class="row">
             <div class="col-12">

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
@@ -1,7 +1,7 @@
 {% if content %}
   {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
   <div class="layout__fixed-width">
     {% if content.first %}
       <div {{ attributes.addClass('max-size-container','center-container', bgcolor, unpublished) }}>

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_fixed_width_section/onecol-fixed-width-section.html.twig
@@ -1,7 +1,7 @@
 {% if content %}
   {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
+  {% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
   <div class="layout__fixed-width">
     {% if content.first %}
       <div {{ attributes.addClass('max-size-container','center-container', bgcolor, unpublished) }}>

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
@@ -1,7 +1,10 @@
+{% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
 {% if content %}
   <div class="row g-0">
     <div class="col uds-full-width">
-      <div{{ attributes.addClass('layout__full-width') }}>
+      <div{{ attributes.addClass('layout__full-width', bgcolor, unpublished) }}>
         {% if content.first %}
           <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
             {{ content.first }}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
@@ -1,6 +1,6 @@
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
 {% if content %}
   <div class="row g-0">
     <div class="col uds-full-width">

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/onecol_full_width_section/onecol-full-width-section.html.twig
@@ -1,6 +1,6 @@
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
 {% if content %}
   <div class="row g-0">
     <div class="col uds-full-width">

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
@@ -11,7 +11,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
 {%
     set container_classes = [
     'clearfix',

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
@@ -11,7 +11,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
 {%
     set container_classes = [
     'clearfix',

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/threecol_fixed_width_section/threecol-fixed-width-section.html.twig
@@ -9,9 +9,14 @@
  * panel of the layout. This layout supports the following sections:
  */
 #}
+{% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
 {%
     set container_classes = [
-    'clearfix'
+    'clearfix',
+    bgcolor,
+    unpublished,
 ]
 %}
 {% if classes %}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
@@ -10,10 +10,12 @@
  * @ingroup themeable
  */
 #}
-
+{% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
 {% if content.first is not empty or content.second is not empty %}
 {% set widths = settings.additional.classes.widths|split('-') %}
-<div {{ attributes }}>
+<div {{ attributes.addClass(bgcolor, unpublished) }}>
   <div class="container">
     <div class="row">
       {% if content.first %}

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
@@ -12,7 +12,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
 {% if content.first is not empty or content.second is not empty %}
 {% set widths = settings.additional.classes.widths|split('-') %}
 <div {{ attributes.addClass(bgcolor, unpublished) }}>

--- a/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
+++ b/web/modules/webspark/webspark_module_renovation_layouts/layouts/twocol_bootstrap_section/layout--twocol-bootstrap-section.html.twig
@@ -12,7 +12,7 @@
 #}
 {% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 {% set bg = settings['additional']['classes']['style'] %}
-{% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+{% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
 {% if content.first is not empty or content.second is not empty %}
 {% set widths = settings.additional.classes.widths|split('-') %}
 <div {{ attributes.addClass(bgcolor, unpublished) }}>

--- a/web/modules/webspark/webspark_module_renovation_layouts/webspark_module_renovation_layouts.module
+++ b/web/modules/webspark/webspark_module_renovation_layouts/webspark_module_renovation_layouts.module
@@ -8,3 +8,14 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
+
+/**
+ * Add is_published template variable.
+ */
+function webspark_module_renovation_layouts_preprocess(&$variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node) {
+    $status = $node->get('status')->value;
+    $variables['is_published'] = $status;
+  }
+}

--- a/web/themes/webspark/renovation/package.json
+++ b/web/themes/webspark/renovation/package.json
@@ -21,7 +21,7 @@
         "sass-loader": "^12.1.0"
     },
     "dependencies": {
-        "@asu/unity-bootstrap-theme": "1.9.8",
+        "@asu/unity-bootstrap-theme": "1.9.9",
         "@popperjs/core": "^2.11.8"
     }
 }

--- a/web/themes/webspark/renovation/package.json
+++ b/web/themes/webspark/renovation/package.json
@@ -21,7 +21,7 @@
         "sass-loader": "^12.1.0"
     },
     "dependencies": {
-        "@asu/unity-bootstrap-theme": "1.9.7",
+        "@asu/unity-bootstrap-theme": "1.9.8",
         "@popperjs/core": "^2.11.8"
     }
 }

--- a/web/themes/webspark/renovation/src/components/node/node.twig
+++ b/web/themes/webspark/renovation/src/components/node/node.twig
@@ -14,9 +14,7 @@
   node.bundle|clean_class ~ '--' ~ view_mode|clean_class,
 ]
 %}
-{% block meta_additions %}
-{% endblock %}
-<article{{ attributes.addClass(classes) }}>
+<article {{ attributes.addClass(classes) }} >
   {{ title_prefix }}
   {{ title_suffix }}
   {% block content %}

--- a/web/themes/webspark/renovation/src/components/node/node.twig
+++ b/web/themes/webspark/renovation/src/components/node/node.twig
@@ -10,12 +10,12 @@
   'node',
   node.isPromoted() ? 'node--promoted',
   node.isSticky() ? 'node--sticky',
-  not node.isPublished() ? 'node--unpublished',
   node.bundle|clean_class,
   node.bundle|clean_class ~ '--' ~ view_mode|clean_class,
 ]
 %}
-
+{% block meta_additions %}
+{% endblock %}
 <article{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {{ title_suffix }}
@@ -23,3 +23,4 @@
     {{ content }}
   {% endblock %}
 </article>
+

--- a/web/themes/webspark/renovation/src/sass/nodes/_node.scss
+++ b/web/themes/webspark/renovation/src/sass/nodes/_node.scss
@@ -1,5 +1,4 @@
-.node {
-  &.node--unpublished {
+.node--unpublished {
     background-color: $uds-color-background-error;
-  }
 }
+

--- a/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
@@ -8,7 +8,7 @@
 
 {% block meta_additions %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
   {% set more_classes = [
     bgcolor,
   ] %}

--- a/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
@@ -4,14 +4,27 @@
  * Template for a Node.
  */
 #}
-{% extends "@renovation/node/node.twig" %}
 
-{% block meta_additions %}
-  {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
-  {% set more_classes = [
-    bgcolor,
-  ] %}
-  {% set classes = classes|merge([more_classes]) %}
-{% endblock %}
+{%
+  set classes = [
+  'node',
+  node.isPromoted() ? 'node--promoted',
+  node.isSticky() ? 'node--sticky',
+  node.bundle|clean_class,
+  node.bundle|clean_class ~ '--' ~ view_mode|clean_class,
+]
+%}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
+{% set more_classes = [
+  bgcolor,
+] %}
+{% set classes = classes|merge(more_classes) %}
+<article {{ attributes.addClass(classes) }} >
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</article>
 

--- a/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-detail-page.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Template for a Node.
+ */
+#}
+{% extends "@renovation/node/node.twig" %}
+
+{% block meta_additions %}
+  {% set bg = settings['additional']['classes']['style'] %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set more_classes = [
+    bgcolor,
+  ] %}
+  {% set classes = classes|merge([more_classes]) %}
+{% endblock %}
+

--- a/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
@@ -8,7 +8,7 @@
 
 {% block meta_additions %}
   {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
   {% set more_classes = [
     bgcolor,
   ] %}

--- a/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Template for a Node.
+ */
+#}
+{% extends "@renovation/node/node.twig" %}
+
+{% block meta_additions %}
+  {% set bg = settings['additional']['classes']['style'] %}
+  {% set bgcolor = bg|length > 0 ? bg|first : 'bg bg-white' %}
+  {% set more_classes = [
+    bgcolor,
+  ] %}
+  {% set classes = classes|merge([more_classes]) %}
+{% endblock %}

--- a/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
+++ b/web/themes/webspark/renovation/templates/content/node--degree-listing-page.html.twig
@@ -4,13 +4,26 @@
  * Template for a Node.
  */
 #}
-{% extends "@renovation/node/node.twig" %}
 
-{% block meta_additions %}
-  {% set bg = settings['additional']['classes']['style'] %}
-  {% set bgcolor = bg|length > 0 ? bg|first : 'bg-white' %}
-  {% set more_classes = [
-    bgcolor,
-  ] %}
-  {% set classes = classes|merge([more_classes]) %}
-{% endblock %}
+{%
+  set classes = [
+  'node',
+  node.isPromoted() ? 'node--promoted',
+  node.isSticky() ? 'node--sticky',
+  node.bundle|clean_class,
+  node.bundle|clean_class ~ '--' ~ view_mode|clean_class,
+]
+%}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
+{% set more_classes = [
+  bgcolor,
+] %}
+{% set classes = classes|merge(more_classes) %}
+<article {{ attributes.addClass(classes) }} >
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</article>

--- a/web/themes/webspark/renovation/templates/page/page.html.twig
+++ b/web/themes/webspark/renovation/templates/page/page.html.twig
@@ -9,8 +9,9 @@
       {{ page.header }}
   </header>
 {% endif %}
+{% set unpublished = is_published is same as '0' ? 'node--unpublished' : '' %}
 <main>
-  <div class="page page-wrapper-webspark">
+  <div class="page page-wrapper-webspark {{ unpublished }}">
     <div class="pt-5 pb-5">
 
       {% if page.pre_content %}

--- a/web/themes/webspark/renovation/templates/views/views-view--page.html.twig
+++ b/web/themes/webspark/renovation/templates/views/views-view--page.html.twig
@@ -37,6 +37,12 @@
     dom_id ? 'js-view-dom-id-' ~ dom_id,
   ]
 %}
+{% set bg = settings['additional']['classes']['style'] %}
+{% set bgcolor = bg|length > 0 ? bg|first is same as 'bg morse-code-white' ? 'bg-white' : bg|first : 'bg-white' %}
+{% set more_classes = [
+  bgcolor,
+] %}
+{% set classes = classes|merge(more_classes) %}
 <div{{ attributes.addClass(classes) }}>
   <div class="container">
     <div class="row">


### PR DESCRIPTION
### Description

This PR updates several twig theme files in order to enforce a white background on nearly all content that is generated by tools provided in Webspark. Primarily, we do this by making content types and Layout Builder sections have the `bg-white` Bootstrap5 class.

The white background change disrupted the existing pink background used to indicate unpublished content. So, I have re-implemented that in a more robust way, by applying the pink background to the page instead of the node template. To accomplish this, I have added a preprocess function that adds a new globally available variable, "is_published." This can be accessed by any twig template, and be used as needed.

QA Test steps:

- Log in to the site as an admin
- Open the Inspector tool and add the style `background-color: red` to the `body` tag on several pages on the site. The main part of the page should not have a red background, but the background should remain white by default.
  - Note that on the homepage, the View gets a `bg-white` class on the view’s parent div.
  - Note that on the Basic Page, Article, Degree Detail, and Degree Listing content types, the `bg-white` class is added to the `<article>` element.
  - Note that each of the custom layout builder layouts that we have added to webspark via the webspark_module_renovation_layouts module have been updated to also include the `bg-white` CSS class.
  - Click into the “Edit” tab for one of the pages you are looking at and uncheck the “Published” checkbox and save it. Upon returning to the View of the node, you should see the pink background has been added to the top where the “precontent” area where the “local task” tabs are located (i.e. View, Edit, Delete, etc). This was done to improve visibility of unpublished content, since the pink background is overridden by this change. This will still alert site maintainers to immediately know if a page is not published while still retaining the white background change.
  - Note that this PR makes it so that if the `morse-code-white` background is used on a section, that it also applies the `bg-white` class, because the morse code background allowed color to bleed through. You can see this by removing the `bg-white` class if you want, after having added a background color to the body element. So, this solves for that scenario.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1656)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

![image](https://github.com/ASUWebPlatforms/webspark-ci/assets/6109406/0fbc2717-4dd0-42e5-9f22-cd39a48502a4)

Note: Sections that are not applicable for this issue can be removed.
