### PR TITLE
WS2 1995: Null warning on every page needs to be fixed

### DIFF
--- a/web/modules/webspark/webspark_blocks/webspark_blocks.module
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.module
@@ -160,12 +160,12 @@ function _webspark_blocks_preprocess_page_404(&$variables) {
   $links = $config->get('webspark_utility_links');
 
   // loop through $links to find any non-empty values
-  // if we find any, we'll display the links  
+  // if we find any, we'll display the links
   // if we don't find any, we'll skip displaying the links
-  
-  foreach ($links as $link) {
-    if (!empty($link['link_url']) && !empty($link['link_title'])) {
-      $has_links = TRUE;
+  if (is_array($links)) {
+    foreach ($links as $link) {
+      if (!empty($link['link_url']) && !empty($link['link_title'])) {
+        $has_links = TRUE;
         if ($has_links) {
           $wrapper['links'] = [
             '#theme' => 'webspark_blocks__links',
@@ -173,12 +173,13 @@ function _webspark_blocks_preprocess_page_404(&$variables) {
             '#links' => $links,
           ];
         }
-      break;
+        break;
+      }
     }
   }
 
   $variables['page']['content']['page_404_content'] = $wrapper;
-  
+
 }
 
 /**


### PR DESCRIPTION
### Description

Php 8 is more strictly typed than previously, so if code expects an array (in a foreach, for example) and gets NULL, it throws a "warning." Adding a conditional prior to the foreach solves this problem.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1995)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
