### PR TITLE
Ws2 2004: Accessibility QA: Profile Edit UI - Tabs

### DIFF
--- a/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
+++ b/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
@@ -4,6 +4,12 @@
       setButtonsCompatibility(e);
     });
 
+    document.querySelectorAll(".nav-item").forEach( tabTitle => {
+      tabTitle.addEventListener("focus", (e) => {
+        tabTitle.scrollIntoView( {block: "nearest"} );
+      })
+    });
+
     document.querySelectorAll(".uds-tabbed-panels").forEach((item) => {
       const nav = item.querySelector(".nav-tabs");
 

--- a/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.twig
+++ b/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.twig
@@ -81,7 +81,8 @@
         class="tab-pane fade show active {{ is_dark ? 'text-white' }}"
         id="nav-{{ tab.heading|clean_id|lower }}"
         role="tabpanel"
-        aria-labelledby="nav-{{ tab.heading|clean_id|lower }}-tab">
+        aria-labelledby="nav-{{ tab.heading|clean_id|lower }}-tab"
+        tabindex="0">
         {{ tab.copy|raw }}
         {{ tab.blocks }}
       </div>
@@ -90,7 +91,8 @@
         class="tab-pane fade {{ is_dark ? 'text-white' }}"
         id="nav-{{ tab.heading|clean_id|lower }}"
         role="tabpanel"
-        aria-labelledby="nav-{{ tab.heading|clean_id|lower }}-tab">
+        aria-labelledby="nav-{{ tab.heading|clean_id|lower }}-tab"
+        tabindex="0">
         {{ tab.copy|raw }}
         {{ tab.blocks }}
       </div>


### PR DESCRIPTION
### Description

Accessibility fixes that hadn't happened yet were for horizontal tab browsing via the keyboard was not using `scrollIntoView`, which is in UDS, so I have added it. Also, WCAG indicates that we need to add `tabindex="0"` to each tab panel's content area for accessibility. So, I have added that as well.

QA Steps:

- Navigate to /tabbed-content
- After the page loads, hit Tab on the keyboard. It should highlight a link that says “Skip to main content.” Press Enter.
- Press Tab again, and the first tab should receive the focus.
  - Use keyboard left/right/up/down arrows to navigate between tabs. 
  - As you get to the edge of visible tabs, it should scroll to reveal more tabs.
- When you get to the last tab, it should “loop around” and focus on the first tab and scroll to it.
- From one of the focused tabs, click Tab again. It should take you to the content of the tab itself and highlight it with a focus ring.

If all of these things happen, this passes!

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2004)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
