### PR TITLE
WS2-1744: JSM - WS2 - Webform (Barrett Student)

### DIFF
--- a/web/themes/webspark/renovation/templates/form/fieldset.html.twig
+++ b/web/themes/webspark/renovation/templates/form/fieldset.html.twig
@@ -28,6 +28,7 @@
     'form-wrapper',
     'card',
     'mb-3',
+    'form-control',
   ]
 %}
 <fieldset{{ attributes.addClass(classes) }}>
@@ -41,6 +42,9 @@
   {#  Always wrap fieldset legends in a SPAN for CSS positioning. #}
   <div class="card-header">
     <legend{{ legend.attributes.addClass('m-0') }}>
+      {% if required %}
+        <span title="Required" class="fa fa-icon fa-circle uds-field-required"></span>
+      {% endif %}
       <span{{ legend_span.attributes.addClass(legend_span_classes) }}>{{ legend.title }}</span>
     </legend>
   </div>


### PR DESCRIPTION
### Description

#### Description of problem
When you use the radio element on webforms and set it to required, the red ‘required asterisk’ don’t show up for the end user
#### Solution 
Added required classes for fieldset in Webforms radios

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1744)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
