### PR TITLE
WS2-2011 add max_age caching config for install and update

### DIFF
--- a/web/profiles/webspark/webspark/config/install/system.performance.yml
+++ b/web/profiles/webspark/webspark/config/install/system.performance.yml
@@ -1,0 +1,3 @@
+cache:
+  page:
+    max_age: 3600

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -532,10 +532,11 @@ function webspark_update_10005(&$sandbox) {
   \Drupal::state()->set('configuration_locked', FALSE);
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('system.performance');
-  // Only set if default of none is configured. Otherwise, we assume the site
-  // owner has intentionally changed the setting.
-  if ($config->get('cache.page.max_age') !== '0') {
-    $config->set('cache.page.max_age', '3600');
+  // Only set if default of zero or none is found. Otherwise, we assume the
+  // site owner has intentionally changed the setting. Using non-typed check so
+  // if there's a null or 0 or even '0' value they'll all get updated.
+  if ($config->get('cache.page.max_age') == 0) {
+    $config->set('cache.page.max_age', 3600);
   }
   $config->save(TRUE);
   \Drupal::state()->set('configuration_locked', TRUE);

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -534,8 +534,8 @@ function webspark_update_10005(&$sandbox) {
   $config = $config_factory->getEditable('system.performance');
   // Only set if default of none is configured. Otherwise, we assume the site
   // owner has intentionally changed the setting.
-  if ($config->get('cache.page.max_age') !== 0) {
-    $config->set('cache.page.max_age', 3600);
+  if ($config->get('cache.page.max_age') !== '0') {
+    $config->set('cache.page.max_age', '3600');
   }
   $config->save(TRUE);
   \Drupal::state()->set('configuration_locked', TRUE);

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -524,3 +524,19 @@ function webspark_update_10004(&$sandbox) {
     \Drupal::state()->set('configuration_locked', TRUE);
   }
 }
+
+/**
+ * WS2-2011: Set TTL to 1 hr
+ */
+function webspark_update_10005(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('system.performance');
+  // Only set if default of none is configured. Otherwise, we assume the site
+  // owner has intentionally changed the setting.
+  if ($config->get('cache.page.max_age') !== 0) {
+    $config->set('cache.page.max_age', 3600);
+  }
+  $config->save(TRUE);
+  \Drupal::state()->set('configuration_locked', TRUE);
+}


### PR DESCRIPTION
### Description

Cache TTL best practices for Pantheon aren't in place.

Set page cache max_age to 3600 seconds (1 hr).

To test:
1. Check that the cache max age settings on the admin performance page is set to 1 hour after this update is applied.
2. With a newly created site, verify that the cache max age is set to 1 hour.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2011)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
