### PR TITLE
WS2-1876: Normalize the location of the Anchor Menu targets markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,5 @@ The benefit of the Pantheon Build Tools workflow is its automated deployment pro
 - [Agile](https://www.atlassian.com/agile)
 
 <div align="right"><a href="#webspark-ci">↑ Top</a></div>
+
+

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--accordion.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--accordion.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,12 +19,10 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
-  {% set unique_id = block.id.value %}
 
+  {% set unique_id = block.id.value %}
   <div class="accordion" id="accordion-{{ unique_id }}">
     {{ content|without('field_color', 'field_anchor_menu_settings', 'field_tooltip', 'field_anchor_menu_settings') }}
   </div>
-
 </div>

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--blockquote.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--blockquote.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {% block content %}
     {{ content|without('field_tooltip', 'field_anchor_menu_settings') }}

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--card-and-image.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--card-and-image.html.twig
@@ -18,6 +18,7 @@
 {% endif %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -25,7 +26,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/cards/' ~ template with {
       image_background: file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value),

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--card-arrangement.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--card-arrangement.html.twig
@@ -10,7 +10,9 @@
   'block-' ~ plugin_id|clean_class,
 ] %}
 {% set class_layout = content['#view_mode'] == 'landscape' ? 'uds-card-arrangement-vertical'%}
+
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +20,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {% block content %}
     {% include '@renovation/cards/card-arrangement.twig' with {

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--card-carousel.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--card-carousel.html.twig
@@ -9,11 +9,11 @@
   'block-' ~ configuration.provider|clean_class,
   'block-' ~ plugin_id|clean_class,
 ] %}
-
 {% set unique_label = configuration['label'] %}
 {% set unique_id = unique_label|replace({' ': '-'}) %}
 
 <div{{ attributes|without('id').addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -21,7 +21,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     <div id="{{ attributes.id }}">
       {{ content.field_tooltip }}

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--card-image-and-content.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--card-image-and-content.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/cards/card-image-and-content.twig' with {
       image_background: file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value),

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--carousel-image.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--carousel-image.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {{ content|without('field_tooltip', 'field_anchor_menu_settings') }}
 </div>

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--content-image.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--content-image.html.twig
@@ -12,6 +12,7 @@
 {% set class_position = content.field_content_position[0]['#markup'] == 'left' ? 'content-left'%}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -19,7 +20,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/image-overlap/image-overlap.twig' with {
       image: content.field_media,

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--gallery.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--gallery.html.twig
@@ -10,7 +10,6 @@
   'block-' ~ plugin_id|clean_class,
 ] %}
 
-
 <div{{ attributes.addClass(classes) }}>
   {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--image-and-text-block.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--image-and-text-block.html.twig
@@ -12,6 +12,7 @@
 {% set class_position = content.field_content_position[0]['#markup'] == 'left' ? 'content-left'%}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -19,7 +20,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {% block content %}
     {% if content.field_content_position[0]['#markup'] == 'left' %}

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--image-background-with-cta.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--image-background-with-cta.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/image-background-with-cta/image-background-with-cta.twig' with {
       heading: content.field_heading[0]['#context']['value'],

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--inset-box.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--inset-box.html.twig
@@ -9,7 +9,9 @@
   'block-' ~ configuration.provider|clean_class,
   'block-' ~ plugin_id|clean_class,
 ] %}
+
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -17,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/inset-box/inset-box.twig' with {
       content: content.field_formatted_text[0],

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--news.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--news.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
 
   <div class="mt-2" id="{{ news_id }}">
     ASU News

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--tabbed-content.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--tabbed-content.html.twig
@@ -11,7 +11,9 @@
 ] %}
 
 {{ content|without('field_background_color', 'field_tab', 'field_tooltip', 'field_anchor_menu_settings') }}
+
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -19,7 +21,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   <div class="{{ content.field_background_color['0']['#markup'] }}">
     {% include '@renovation/tabbed-panels/tabbed-panels.twig' with {
       tabs: tabs,

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial-on-image-background.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial-on-image-background.html.twig
@@ -9,7 +9,9 @@
   'block-' ~ configuration.provider|clean_class,
   'block-' ~ plugin_id|clean_class,
 ] %}
+
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -17,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {% block content %}
     {% include '@renovation/quote-image-background/quote-image-background.twig' with {
       image: file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value),

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {% block content %}
     {{ content|without('field_tooltip', 'field_anchor_menu_settings', 'field_accent_color', 'field_heading_highlight') }}

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--text-content.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--text-content.html.twig
@@ -13,6 +13,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {# To allow contextual links to display the title_suffix is required. #}
   {{ title_prefix }}
   {% if label %}
@@ -21,7 +22,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {{ content|without('field_anchor_menu_settings', 'field_tooltip') }}
 </div>

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--video.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--video.html.twig
@@ -10,8 +10,8 @@
   'block-' ~ plugin_id|clean_class,
 ] %}
 
-
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {# To allow contextual links to display the title_suffix is required. #}
   {{ title_prefix }}
   {% if label %}
@@ -20,9 +20,9 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {{ content|without('field_tooltip', 'field_anchor_menu_settings', 'field_image_caption') }}
+
   {% if content.field_image_caption|render %}
     <div class="uds-video-container uds-video-with-caption">
       <figure>
@@ -30,5 +30,4 @@
       </figure>
     </div>
   {% endif %}
-
 </div>

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--webform.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--webform.html.twig
@@ -11,6 +11,7 @@
 ] %}
 
 <div{{ attributes.addClass(classes) }}>
+  {{ content.field_anchor_menu_settings }}
   {{ title_prefix }}
   {% if label %}
     {% block label %}
@@ -18,7 +19,6 @@
     {% endblock %}
   {% endif %}
   {{ title_suffix }}
-  {{ content.field_anchor_menu_settings }}
   {{ content.field_tooltip }}
   {{ content|without('field_tooltip', 'field_anchor_menu_settings') }}
 </div>


### PR DESCRIPTION
### Description

Currently, when clicking a link for the Anchor Menu, the page will scroll to the block, but the Anchor Menu will cover the block's title if it is visible. This PR normalizes the location of the Anchor Menu target markup in block templates, so that the target is now the first element in the block.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1876)

### Checklist

- Solution is documented on the Jira ticket
- QA steps to verify have been included on the Jira ticket
- No new PHP or JS errors
- No accessibility issues are introduced with this update

### Verified in browsers 

- Chrome
