### PR TITLE
WS2-2021: Keep the toolbar fixed at all times

### DIFF
--- a/web/modules/webspark/asu_brand/css/asu_brand.header.css
+++ b/web/modules/webspark/asu_brand/css/asu_brand.header.css
@@ -176,3 +176,8 @@ body.toolbar-vertical.toolbar-tray-open {
     top: 0.55rem
   }
 }
+
+/* WS2-2021: Keep the admin toolbar fixed at all times */
+#toolbar-bar {
+  position: fixed;
+}


### PR DESCRIPTION
### Description

Drupal 10 appears to have changed some CSS so that the admin toolbar is no longer fixed on mobile. This PR adds a simple CSS rule to keep the toolbar fixed at all times. This is not targeting mobile only because our header is also fixed at all times.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2021)

### Checklist

- Solution is documented on the Jira ticket
- QA steps to verify have been included on the Jira ticket
- No new PHP or JS errors
- No accessibility issues are introduced with this update

### Verified in browsers 

- Chrome
