### PR TITLE
WS2-2059: Update Drush version to avoid error caused by webflo/drupal-finder

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5192,23 +5192,23 @@
         },
         {
             "name": "drush/drush",
-            "version": "12.4.3",
+            "version": "12.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "8245acede57ecc62a90aa0f19ff3b29e5f11f971"
+                "reference": "4aebed85dc818ff762f2e24a85b023d2a52050df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/8245acede57ecc62a90aa0f19ff3b29e5f11f971",
-                "reference": "8245acede57ecc62a90aa0f19ff3b29e5f11f971",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/4aebed85dc818ff762f2e24a85b023d2a52050df",
+                "reference": "4aebed85dc818ff762f2e24a85b023d2a52050df",
                 "shasum": ""
             },
             "require": {
                 "chi-teck/drupal-code-generator": "^3.0",
                 "composer-runtime-api": "^2.2",
                 "composer/semver": "^1.4 || ^3",
-                "consolidation/annotated-command": "^4.9.1",
+                "consolidation/annotated-command": "^4.9.2",
                 "consolidation/config": "^2.1.2",
                 "consolidation/filter-via-dot-access-data": "^2.0.2",
                 "consolidation/output-formatters": "^4.3.2",
@@ -5324,7 +5324,7 @@
                 "issues": "https://github.com/drush-ops/drush/issues",
                 "security": "https://github.com/drush-ops/drush/security/advisories",
                 "slack": "https://drupal.slack.com/messages/C62H9CWQM",
-                "source": "https://github.com/drush-ops/drush/tree/12.4.3"
+                "source": "https://github.com/drush-ops/drush/tree/12.5.2"
             },
             "funding": [
                 {
@@ -5332,7 +5332,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-16T22:57:24+00:00"
+            "time": "2024-05-02T17:20:48+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -6524,11 +6524,11 @@
         },
         {
             "name": "pantheon-upstreams/upstream-configuration",
-            "version": "2.12.2",
+            "version": "2.12.1",
             "dist": {
                 "type": "path",
                 "url": "upstream-configuration",
-                "reference": "370bc3d76f2fd5aa55882c90f6c05ddb00d8720a"
+                "reference": "7b267bb846454f36c666bad220056c2d68db2eab"
             },
             "require": {
                 "composer/installers": "v2.0.0",
@@ -6581,7 +6581,7 @@
                 "drupal/simple_sitemap": "4.1.8",
                 "drupal/webform": "6.2.2",
                 "drush-ops/behat-drush-endpoint": "9.4.1",
-                "drush/drush": "^11 || 12.4.3",
+                "drush/drush": "^11 || ^12.4.3",
                 "fontawesome/fontawesome": "6.4.2",
                 "northernco/ckeditor5-anchor-drupal": "0.4.0",
                 "npm-asset/fonticonpicker--fonticonpicker": "3.1.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -47,7 +47,7 @@
         "drupal/select2": "1.15.0",
         "drupal/simple_sitemap": "4.1.8",
         "drupal/webform": "6.2.2",
-        "drush/drush": "^11 || 12.4.3",
+        "drush/drush": "^11 || ^12.4.3",
         "drush-ops/behat-drush-endpoint": "9.4.1",
         "fontawesome/fontawesome": "6.4.2",
         "npm-asset/fonticonpicker--fonticonpicker": "3.1.1",


### PR DESCRIPTION
### Description

#### Description of problem
Need a update of Drush version to avoid error caused by webflo/drupal-finder
#### Solution
Update Drush version to avoid error caused by webflo/drupal-finder
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2059)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
