### PR TITLE
WS2-2029: Anchor Menu links do not properly highlight the active area

### DIFF
--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -88,22 +88,32 @@
       navbar.classList.add("uds-anchor-menu-attached");
     }
 
+    /**
+     * Calculates the percentage of an element that is visible in the viewport.
+     *
+     * @param {Element} el The element to calculate the visible percentage for.
+     * @return {number} The percentage of the element that is visible in the viewport.
+     */
     function calculateVisiblePercentage(el) {
       const rect = el.getBoundingClientRect();
       const windowHeight = window.innerHeight || document.documentElement.clientHeight;
       const windowWidth = window.innerWidth || document.documentElement.clientWidth;
-  
+
+      // Get the dimensions of the element
       const elHeight = rect.bottom - rect.top;
       const elWidth = rect.right - rect.left;
-  
+
+      // Calculate the area of the element
       const elArea = elHeight * elWidth;
-  
+
+      // Calculate the visible area of the element in the viewport
       const visibleHeight = Math.min(windowHeight, rect.bottom) - Math.max(0, rect.top);
       const visibleWidth = Math.min(windowWidth, rect.right) - Math.max(0, rect.left);
       const visibleArea = visibleHeight * visibleWidth;
-  
+
+      // Calculate the percentage of the element that is visible in the viewport
       const visiblePercentage = (visibleArea / elArea) * 100;
-  
+
       return visiblePercentage;
     }
 
@@ -112,12 +122,12 @@
       let max = 0;
       elements.forEach(function(el) {
         const parentVisiblePercentage = calculateVisiblePercentage(el.parentNode);
-        if(parentVisiblePercentage > 0 && parentVisiblePercentage > max) {
+        if (parentVisiblePercentage > 0 && parentVisiblePercentage > max) {
           max = parentVisiblePercentage;
           document.querySelector('[href="#' + el.id + '"]').classList.add('active');
           document.querySelectorAll('a[href^="#webspark-anchor-link--"]:not([href="#' + el.id + '"])').forEach(function(e) {
-              e.classList.remove('active');
-            });
+            e.classList.remove('active');
+          });
         }
       });
 

--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -89,29 +89,29 @@
     }
 
     function calculateVisiblePercentage(el) {
-      var rect = el.getBoundingClientRect();
-      var windowHeight = window.innerHeight || document.documentElement.clientHeight;
-      var windowWidth = window.innerWidth || document.documentElement.clientWidth;
+      const rect = el.getBoundingClientRect();
+      const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+      const windowWidth = window.innerWidth || document.documentElement.clientWidth;
   
-      var elHeight = rect.bottom - rect.top;
-      var elWidth = rect.right - rect.left;
+      const elHeight = rect.bottom - rect.top;
+      const elWidth = rect.right - rect.left;
   
-      var elArea = elHeight * elWidth;
+      const elArea = elHeight * elWidth;
   
-      var visibleHeight = Math.min(windowHeight, rect.bottom) - Math.max(0, rect.top);
-      var visibleWidth = Math.min(windowWidth, rect.right) - Math.max(0, rect.left);
-      var visibleArea = visibleHeight * visibleWidth;
+      const visibleHeight = Math.min(windowHeight, rect.bottom) - Math.max(0, rect.top);
+      const visibleWidth = Math.min(windowWidth, rect.right) - Math.max(0, rect.left);
+      const visibleArea = visibleHeight * visibleWidth;
   
-      var visiblePercentage = (visibleArea / elArea) * 100;
+      const visiblePercentage = (visibleArea / elArea) * 100;
   
       return visiblePercentage;
     }
 
     window.addEventListener("scroll", function () {
-      var elements = document.querySelectorAll('[id^="webspark-anchor-link--"]');
+      const elements = document.querySelectorAll('[id^="webspark-anchor-link--"]');
       let max = 0;
       elements.forEach(function(el) {
-        var parentVisiblePercentage = calculateVisiblePercentage(el.parentNode);
+        const parentVisiblePercentage = calculateVisiblePercentage(el.parentNode);
         if(parentVisiblePercentage > 0 && parentVisiblePercentage > max) {
           max = parentVisiblePercentage;
           document.querySelector('[href="#' + el.id + '"]').classList.add('active');

--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -81,16 +81,6 @@
       anchorTargets.set(anchor, target);
     }
 
-    /*
-      Bootstrap needs to be loaded as a variable in order for this to work.
-      An alternative is to remove this and add the data-bs-spy="scroll" data-bs-target="#uds-anchor-menu nav" attributes to the body tag
-      See https://getbootstrap.com/docs/5.3/components/scrollspy/ for more info
-    */
-    const scrollSpy = new bootstrap.ScrollSpy(body, {
-      target: '#uds-anchor-menu nav',
-      rootMargin: '20%'
-    });
-
     const shouldAttachNavbarOnLoad = window.scrollY > navbarInitialTop;
     if (shouldAttachNavbarOnLoad) {
       globalHeader.appendChild(navbar);
@@ -98,7 +88,39 @@
       navbar.classList.add("uds-anchor-menu-attached");
     }
 
+    function calculateVisiblePercentage(el) {
+      var rect = el.getBoundingClientRect();
+      var windowHeight = window.innerHeight || document.documentElement.clientHeight;
+      var windowWidth = window.innerWidth || document.documentElement.clientWidth;
+  
+      var elHeight = rect.bottom - rect.top;
+      var elWidth = rect.right - rect.left;
+  
+      var elArea = elHeight * elWidth;
+  
+      var visibleHeight = Math.min(windowHeight, rect.bottom) - Math.max(0, rect.top);
+      var visibleWidth = Math.min(windowWidth, rect.right) - Math.max(0, rect.left);
+      var visibleArea = visibleHeight * visibleWidth;
+  
+      var visiblePercentage = (visibleArea / elArea) * 100;
+  
+      return visiblePercentage;
+    }
+
     window.addEventListener("scroll", function () {
+      var elements = document.querySelectorAll('[id^="webspark-anchor-link--"]');
+      let max = 0;
+      elements.forEach(function(el) {
+        var parentVisiblePercentage = calculateVisiblePercentage(el.parentNode);
+        if(parentVisiblePercentage > 0 && parentVisiblePercentage > max) {
+          max = parentVisiblePercentage;
+          document.querySelector('[href="#' + el.id + '"]').classList.add('active');
+          document.querySelectorAll('a[href^="#webspark-anchor-link--"]:not([href="#' + el.id + '"])').forEach(function(e) {
+              e.classList.remove('active');
+            });
+        }
+      });
+
       const navbarY = navbar.getBoundingClientRect().top;
       const headerHeight = globalHeader.classList.contains("scrolled") ?  globalHeader.offsetHeight - 32 : globalHeader.offsetHeight; // 32 is the set height of the gray toolbar above the global header.
 


### PR DESCRIPTION
### Description

#### Description of problem
Anchor Menu links do not properly highlight the active area
#### Solution
Removed Bootstrap scrollspy from anchor-menu.js and I added a new custom functionality

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2029)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
