### PR TITLE
Ws2 2071: Fix Call to Action button regression

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -1,7 +1,7 @@
 {
     "drupal/core": {
         "#2951547: Fix issue with layout overflow": "https://www.drupal.org/files/issues/2022-07-13/f245f21ea664f22c81d8d28c6f0f4a42fb9a5890.patch",
-        "3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2024-02-15/drupal-n3109650-72-102x.patch"
+        "3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2024-05-16/core-10.2.3-xss-refactor_filter_attributes-3109650-74.patch"
     },
     "drupal/config_readonly": {
         "#3085001: Config blacklist to only block some configuration while in read only mode": "https://www.drupal.org/files/issues/2019-10-31/config_readonly-3085001-2.patch"

--- a/web/themes/webspark/renovation/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/webspark/renovation/templates/paragraphs/paragraph--cta.html.twig
@@ -8,8 +8,8 @@
       {% include '@renovation/buttons/button-action.twig' with {
         url : content.field_cta_link[0]['#url'],
         title: content.field_cta_link[0]['#title'],
-        button_color: content.field_cta_link[0]['#options']['attributes']['class'],
-        target: content.field_cta_link[0]['#options']['attributes']['target'],
+        button_color: content.field_cta_link[0]['#url'].options['attributes']['class'],
+        target: content.field_cta_link[0]['#url'].options['attributes']['target'],
         heading: heading,
         sub_heading: sub_heading,
       } %}
@@ -18,8 +18,8 @@
         url : content.field_cta_link[0]['#url'],
         title: content.field_cta_link[0]['#title'],
         icon: content.field_icon[0]['#icons'][0]['#name'],
-        button_color: content.field_cta_link[0]['#options']['attributes']['class'],
-        target: content.field_cta_link[0]['#options']['attributes']['target'],
+        button_color: content.field_cta_link[0]['#url'].options['attributes']['class'],
+        target: content.field_cta_link[0]['#url'].options['attributes']['target'],
         heading: heading,
         sub_heading: sub_heading,
       } %}
@@ -28,7 +28,7 @@
         url : content.field_cta_link[0]['#url'],
         title: content.field_cta_link[0]['#title'],
         button_color: bg_color == 'banner-black' ? 'btn-gold' : 'btn-dark',
-        target: content.field_cta_link[0]['#options']['attributes']['target'],
+        target: content.field_cta_link[0]['#url'].options['attributes']['target'],
         heading: heading,
         sub_heading: sub_heading,
       } %}


### PR DESCRIPTION
### Description
I was able to determine that there were two problems with the commit Dave mentioned. One problem is that the patch didn’t work as expected. However, the patch is not what caused the problem. In fact, the problem was caused by this commit to Drupal core: https://git.drupalcode.org/project/drupal/-/commit/7dcd798ed943910e37cfe264dd1a7998ce1e1ac8

That commit is associated with the following bug ticket: https://www.drupal.org/project/drupal/issues/2885351

Since it was committed, other tickets have sprung up pointing out the issue Dave mentioned above. Two of these are: https://www.drupal.org/project/link_attributes/issues/3423171 and [https://www.drupal.org/project/drupal/issues/3423031](https://www.drupal.org/project/drupal/issues/3423031#comment-15460860). Both of these tickets recommend making a change in the twig file to pull the data from the options object instead of the [#options] array, which no longer exists. So, this is what I have done.

### Testing

This is pretty easy to test. Go to the Kitchen Sink page and verify that the CTA buttons have appropriate background colors on the hero and the “Empowering Creators” and “Unified Branding” image and text blocks and the “Experience Our Design System in Action” video hero. If so, it passes.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2071)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
