### PR TITLE
WS2-1934: Modified default values like '' or ' ' in List(Text) fields

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.grid_links.field_links_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.grid_links.field_links_color.yml
@@ -16,7 +16,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: "' '"
+    value: "text-gray-7"
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.testimonial.field_accent_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.testimonial.field_accent_color.yml
@@ -16,7 +16,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: "''"
+    value: "accent-gray"
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.testimonial_on_image_background.field_accent_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.testimonial_on_image_background.field_accent_color.yml
@@ -16,7 +16,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: "''"
+    value: "accent-gray"
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_accent_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_accent_color.yml
@@ -11,7 +11,7 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: "''"
+      value: "accent-gray"
       label: 'Gray 7'
     -
       value: accent-maroon

--- a/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_card_arrangement_display.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_card_arrangement_display.yml
@@ -11,7 +11,7 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: "''"
+      value: "two-columns"
       label: 'Two Columns'
     -
       value: three-columns

--- a/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_links_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.storage.block_content.field_links_color.yml
@@ -11,7 +11,7 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: "' '"
+      value: "text-gray-7"
       label: 'Gray 7 Links'
     -
       value: text-gold

--- a/web/modules/webspark/webspark_blocks/config/install/field.storage.paragraph.field_accent_color.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.storage.paragraph.field_accent_color.yml
@@ -11,7 +11,7 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: "''"
+      value: "accent-gray"
       label: 'Gray 7'
     -
       value: accent-maroon

--- a/web/modules/webspark/webspark_blocks/config/install/field.storage.paragraph.field_citation_style.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.storage.paragraph.field_citation_style.yml
@@ -11,7 +11,7 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: "''"
+      value: "default"
       label: Default
     -
       value: alt-citation

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -451,6 +451,7 @@ function webspark_blocks_update_10003(&$sandbox) {
     'field.storage.paragraph.field_citation_style',
     'field.storage.block_content.field_card_arrangement_display',
     'field.storage.block_content.field_links_color',
+    'field.storage.block_content.field_accent_color',
    ];
   _webspark_blocks_update_module_config_list($configs);
 }

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -474,6 +474,9 @@ function webspark_blocks_update_10005(&$sandbox) {
     'field.storage.block_content.field_card_arrangement_display',
     'field.storage.block_content.field_links_color',
     'field.storage.block_content.field_accent_color',
+    'field.field.block_content.testimonial.field_accent_color',
+    'field.field.block_content.grid_links.field_links_color',
+    'field.field.block_content.testimonial_on_image_background.field_accent_color',
    ];
    _webspark_blocks_update_module_config_list($configs);
 }

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -385,6 +385,10 @@ function webspark_blocks_update_10003(&$sandbox) {
     'field_links_color' => 'text-gray-7',
   ];
 
+  // Update Paragraph content type fields.
+  // For each Paragraph content type, load the fields and iterate over the
+  // entities. If the field exists and has an empty value or a blank value, update the field
+  // value to the expected value.
   $paragraph_types = ParagraphsType::loadMultiple();
   $paragraph_storage = \Drupal::entityTypeManager()->getStorage('paragraph');
   foreach ($paragraph_types as $type) {
@@ -394,7 +398,6 @@ function webspark_blocks_update_10003(&$sandbox) {
     foreach ($fields_to_check as $field_name => $expected_value) {
       if (isset($fields[$field_name])) {
         $query = $paragraph_storage->getQuery();
-        $orGroup = $query->orConditionGroup()->condition($field_name,'')->condition($field_name,' ');
 
         $result = $query
           ->condition('type', $type_id)
@@ -411,10 +414,11 @@ function webspark_blocks_update_10003(&$sandbox) {
             }
           }
         }
-
       }
     }
   }
+
+  // Apply same for logic on Blocks.
   $block_content_types = BlockContentType::loadMultiple();
   $blockStorage = \Drupal::entityTypeManager()->getStorage('block_content');
   foreach ($block_content_types as $block_content_type) {

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -2,6 +2,8 @@
 
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Config\FileStorage;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\block_content\Entity\BlockContentType;
 
 /**
  * Removes the basic block entities and basic block entity type.
@@ -364,6 +366,87 @@ function webspark_blocks_update_10002(&$sandbox) {
     'field.field.block_content.image.field_media',
     'field.field.paragraph.card.field_media',
     'field.storage.media.field_media_image'
+   ];
+  _webspark_blocks_update_module_config_list($configs);
+}
+
+/**
+ *
+ * WS2-1934 - Modified default value like '' or ' ' in List(Text) fields.
+ */
+function webspark_blocks_update_10003(&$sandbox) {
+
+  $entity_field_manager = \Drupal::service('entity_field.manager');
+
+  $fields_to_check = [
+    'field_accent_color' => 'accent-gray',
+    'field_card_arrangement_display' => 'two-columns',
+    'field_citation_style' => 'default',
+    'field_links_color' => 'text-gray-7',
+  ];
+
+  $paragraph_types = ParagraphsType::loadMultiple();
+  $paragraph_storage = \Drupal::entityTypeManager()->getStorage('paragraph');
+  foreach ($paragraph_types as $type) {
+    $type_id = $type->id();
+    $fields = $entity_field_manager->getFieldDefinitions('paragraph', $type_id);
+
+    foreach ($fields_to_check as $field_name => $expected_value) {
+      if (isset($fields[$field_name])) {
+        $query = $paragraph_storage->getQuery();
+        $orGroup = $query->orConditionGroup()->condition($field_name,'')->condition($field_name,' ');
+
+        $result = $query
+          ->condition('type', $type_id)
+          ->accessCheck(FALSE)
+          ->execute();
+      
+        $paragraphs = $paragraph_storage->loadMultiple($result);
+       
+        foreach ($paragraphs as $p) {
+          if ($p->hasField($field_name)) {
+            if ($p->get($field_name)->value == "''" || $p->get($field_name)->value == "' '") {
+              $p->set($field_name, $expected_value);
+              $p->save();
+            }
+          }
+        }
+
+      }
+    }
+  }
+  $block_content_types = BlockContentType::loadMultiple();
+  $blockStorage = \Drupal::entityTypeManager()->getStorage('block_content');
+  foreach ($block_content_types as $block_content_type) {
+    $type_id = $block_content_type->id();
+    $fields = $entity_field_manager->getFieldDefinitions('block_content', $type_id);
+
+    foreach ($fields_to_check as $field_name => $expected_value) {
+      if (isset($fields[$field_name])) {
+        $block_ids = $blockStorage->getQuery()
+          ->condition('type', $type_id)
+          ->accessCheck(false)
+          ->execute();
+        $blocks = $blockStorage->loadMultiple($block_ids);
+
+        foreach ($blocks as $b) {
+          if ($b->hasField($field_name)) {
+            if ($b->get($field_name)->value == "''" || $b->get($field_name)->value == "' '") {
+              $b->set($field_name, $expected_value);
+              $b->save();
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  $configs = [
+    'field.storage.paragraph.field_accent_color',
+    'field.storage.paragraph.field_citation_style',
+    'field.storage.block_content.field_card_arrangement_display',
+    'field.storage.block_content.field_links_color',
    ];
   _webspark_blocks_update_module_config_list($configs);
 }

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.module
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.module
@@ -81,7 +81,7 @@ function webspark_blocks_form_alter(&$form, FormStateInterface $form_state, $for
         $column_values = [];
         foreach ($field_definition->getSetting('allowed_values') as $key => $value) {
           //Comparing against Two columns option
-          if ($key != "''") {
+          if ($key != "''" && $key != "two-columns") { //WS2-1934: Adding two columns option
             $column_values[] = [$key => $value];
           }
         }


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Modified default values like '' or ' ' in List(Text) fields

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1934)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
