### PR TITLE
WS2-2075: Added new check in asu_brand_header.js if user is admin or not

### DIFF
--- a/web/modules/webspark/asu_brand/js/asu_brand.header.js
+++ b/web/modules/webspark/asu_brand/js/asu_brand.header.js
@@ -117,7 +117,9 @@
             headerElement.classList.remove("asu-brand-toolbar-header-tray-closed-compat" + vertSuffix);
             headerElement.classList.remove("asu-brand-toolbar-header-tray-closed-compat");
             // Set for current state.
-            headerElement.classList.add("asu-brand-toolbar-header-tray-closed-compat" + classSuffix);
+            if(drupalSettings.is_admin) {
+              headerElement.classList.add("asu-brand-toolbar-header-tray-closed-compat" + classSuffix);
+            }
           }
         }
 

--- a/web/modules/webspark/asu_brand/js/asu_brand.header.js
+++ b/web/modules/webspark/asu_brand/js/asu_brand.header.js
@@ -116,8 +116,9 @@
             headerElement.classList.remove("asu-brand-toolbar-header-tray-open-compat");
             headerElement.classList.remove("asu-brand-toolbar-header-tray-closed-compat" + vertSuffix);
             headerElement.classList.remove("asu-brand-toolbar-header-tray-closed-compat");
-            // Set for current state.
-            if(drupalSettings.is_admin) {
+            // Adding class only when user is an admin.
+            if (drupalSettings.is_admin) {
+              // Set for current state.
               headerElement.classList.add("asu-brand-toolbar-header-tray-closed-compat" + classSuffix);
             }
           }

--- a/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -146,7 +146,7 @@ class AsuBrandHeaderBlock extends BlockBase {
     // Get and pass cookie consent status, too.
     $global_config = \Drupal::config('asu_brand.settings');
     $block_output['#attached']['drupalSettings']['asu_brand']['cookie_consent'] = $global_config->get('asu_brand.asu_brand_cookie_consent_enabled');
-
+    $block_output['#attached']['drupalSettings']['is_admin'] = \Drupal::currentUser()->hasPermission('administer site configuration');
     return $block_output;
   }
 


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Added new check in asu_brand_header.js if user is admin or not

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2075)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
