### PR TITLE
WS2-2035: Removing crop options (1:1, image and 16:9) from content image overlap block.

### DIFF
--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.content_image.field_media.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.content_image.field_media.yml
@@ -4,9 +4,6 @@ dependencies:
   config:
     - block_content.type.content_image
     - field.storage.block_content.field_media
-    - media.type.cropped_image_sqare
-    - media.type.cropped_image_wide
-    - media.type.image
     - media.type.image_block_images
 id: block_content.content_image.field_media
 field_name: field_media

--- a/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.content_image.field_media.yml
+++ b/web/modules/webspark/webspark_blocks/config/install/field.field.block_content.content_image.field_media.yml
@@ -20,9 +20,6 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
-      cropped_image_sqare: cropped_image_sqare
-      cropped_image_wide: cropped_image_wide
-      image: image
     sort:
       field: _none
       direction: ASC

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -369,6 +369,17 @@ function webspark_blocks_update_10002(&$sandbox) {
 }
 
 /**
+ * 
+ * WS2-2035
+ */
+function webspark_blocks_update_10003(&$sandbox) {
+  $configs = [
+    'field.field.block_content.content_image.field_media.yml'
+  ];
+  _webspark_blocks_update_module_config_list($configs);
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -374,7 +374,7 @@ function webspark_blocks_update_10002(&$sandbox) {
  */
 function webspark_blocks_update_10003(&$sandbox) {
   $configs = [
-    'field.field.block_content.content_image.field_media.yml'
+    'field.field.block_content.content_image.field_media'
   ];
   _webspark_blocks_update_module_config_list($configs);
 }


### PR DESCRIPTION
### Description

<!-- Description of problem -->
As a user of the content image overlap block, if you use a 4:3 aspect ratio the image sizes crop correctly.  If you use the Cropped image square (1:1), Cropped image wide (16:9), or image, (see below screen shot) the image gets cut off on the output.
<!-- Solution -->
Remove the crop options  (1:1, image and 16:9)
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2035)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->
![image](https://github.com/ASUWebPlatforms/webspark-ci/assets/99989701/ff44566f-0fdf-4053-b95a-3b20dc4725b0)


Note: Sections that are not applicable for this issue can be removed.
