### PR TITLE
WS2-2070: Fixing anchor color for ckeditor (change it to maroon).

### DIFF
--- a/web/themes/webspark/renovation/css/ckeditor-override.css
+++ b/web/themes/webspark/renovation/css/ckeditor-override.css
@@ -161,6 +161,14 @@ button.media-library-item__edit {
   margin: 0 !important;
 }
 
+div.ck.ck-editor__main > div > p > a {
+  color: rgba(var(--bs-link-color-rgb),var(--bs-link-opacity,1));
+  text-decoration: underline;
+}
+div.ck.ck-editor__main > div > p > a:hover {
+  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+}
+
 @media screen and (max-width: 480px) {
   .details-wrapper th {
     display: none;

--- a/web/themes/webspark/renovation/css/ckeditor-override.css
+++ b/web/themes/webspark/renovation/css/ckeditor-override.css
@@ -161,12 +161,8 @@ button.media-library-item__edit {
   margin: 0 !important;
 }
 
-div.ck.ck-editor__main > div > p > a {
-  color: rgba(var(--bs-link-color-rgb),var(--bs-link-opacity,1));
-  text-decoration: underline;
-}
-div.ck.ck-editor__main > div > p > a:hover {
-  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+.ck a, .ck a:hover {
+  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
### Description

<!-- Description of problem -->
The visual editor in the body displays hyperlinks as blue.
<!-- Solution -->
Create a new css rule to override the hyperlink color.
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2070)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge

### Screenshots

![maroonhyperlink](https://github.com/ASUWebPlatforms/webspark-ci/assets/99989701/10509719-06b1-46e5-9c1e-b35b54541e88)

Note: Sections that are not applicable for this issue can be removed.
