### PR TITLE
WS2-1676: Site spin up/config - Parent unit info fields UI clarification

### DIFF
--- a/web/profiles/webspark/webspark/modules/webspark_installer_forms/src/Form/WebsparkConfigureHeaderForm.php
+++ b/web/profiles/webspark/webspark/modules/webspark_installer_forms/src/Form/WebsparkConfigureHeaderForm.php
@@ -56,6 +56,9 @@ class WebsparkConfigureHeaderForm extends ConfigFormBase {
       '#type' => 'url',
       '#default_value' => '',
       '#states' => [
+        'visible' => [
+          ':input[name="parent_unit_name"]' => ['filled' => TRUE],
+        ],
         'required' => [
           ':input[name="parent_unit_name"]' =>['filled' => TRUE],
         ],


### PR DESCRIPTION
**WS2-1936 (PR 464) unblocks this PR and must be merged before merging this PR**

### Description

During WS2 spin up/site config, Parent unit name and Parent Department URL fields are optional, but become required (asterisk appears) when user enters one of the values. This is intended functionality because one depends on the other, however, it might need some enhancement so users know if one field is populated, both fields become required.

### Solution

Make Parent Department URL field only display when Parent unit name field is populated.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1676)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
