### PR TITLE
WS2-2088 fix missing config lock after update

### DIFF
--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -544,5 +544,6 @@ function webspark_update_10005(&$sandbox) {
       $config->set('cache.page.max_age', 86400);
     }
     $config->save(TRUE);
+    \Drupal::state()->set('configuration_locked', TRUE);
   }
 }


### PR DESCRIPTION
Fix missing lock found as part of release prep.

Was accidentally dropped form here: https://github.com/ASUWebPlatforms/webspark-ci/pull/451/files