### PR TITLE
WS2 release prep - Linkit patch has newer version that looks to be pr…

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -10,7 +10,7 @@
         "#3225009: Cant add custom block with field states ui using layout builder": "https://www.drupal.org/files/issues/2023-06-21/3225009-6.patch"
     },
     "drupal/linkit": {
-        "2877535: Fix issue with path alias": "https://www.drupal.org/files/issues/2022-06-07/2877535-39.patch"
+        "2877535: Fix issue with path alias": "https://www.drupal.org/files/issues/2023-10-05/linkit-2877535-64.patch"
     },
     "drupal/fontawesome": {
         "#3274028: Fixing CKEditor 5 compatibility": "https://www.drupal.org/files/issues/2024-01-17/ckeditor_compatibility_issue_0.patch",


### PR DESCRIPTION
…eferred version

This moves us to the latest, version of the patch for [Show URL alias after autocomplete selection instead of internal route (e.g., /node/123)](https://www.drupal.org/node/2877535).

Steps to test - 
1. Create a link in WS2's CKEditor and verify that the URL alias is displayed instead of the internal node/N route.
2. Verify existing links aren't harmed. (See Text Content page for example link to use).