### PR TITLE
WS2-1834: Added new classes for uds-img-rounded and configs to remove transparent functionality in image styles

### DIFF
--- a/web/modules/webspark/webspark_cropper_theme/css/rounded.css
+++ b/web/modules/webspark/webspark_cropper_theme/css/rounded.css
@@ -10,5 +10,8 @@ form[action*='media_library_selected_type=cropped_image_rounded_1_1'] .cropper-f
 .uds-img-rounded img {
     border: 0;
     border-radius: 100% !important;
-    max-width: max-content;
+}
+
+.uds-img-rounded .field--name-thumbnail img {
+  max-width: max-content;
 }

--- a/web/modules/webspark/webspark_cropper_theme/css/rounded.css
+++ b/web/modules/webspark/webspark_cropper_theme/css/rounded.css
@@ -6,3 +6,9 @@ form[action*='media_library_selected_type=cropped_image_rounded_1_1'] .cropper-f
 #media-cropped-image-rounded-1-1-add-form .cropper-face {
   border-radius: 50%;
 }
+
+.uds-img-rounded img {
+    border: 0;
+    border-radius: 100% !important;
+    max-width: max-content;
+}

--- a/web/modules/webspark/webspark_cropper_theme/templates/media--media-library.html.twig
+++ b/web/modules/webspark/webspark_cropper_theme/templates/media--media-library.html.twig
@@ -41,7 +41,9 @@
 <article{{ attributes.addClass('media-library-item__preview-wrapper') }}>
   {% if content %}
     <div{{ preview_attributes.addClass('media-library-item__preview js-media-library-item-preview') }}>
+      <div class="{{ 'rounded' in content.thumbnail['#bundle']  ? 'uds-img-rounded' : '' }}">
       {{ content|without('name') }}
+      </div>
     </div>
     {% if not status %}
       <div class="media-library-item__status">{{ "unpublished"|t }}</div>

--- a/web/modules/webspark/webspark_cropper_theme/webspark_cropper_theme.install
+++ b/web/modules/webspark/webspark_cropper_theme/webspark_cropper_theme.install
@@ -1,0 +1,32 @@
+<?php
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\Core\Config\FileStorage;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\block_content\Entity\BlockContentType;
+
+/**
+ *
+ * WS2-1834 - Remove transparent background for image styles.
+ */
+function webspark_cropper_theme_update_10000(&$sandbox) {
+  $configs = [
+    'image.style.block_image_1_1_lge_rounded',
+    'image.style.block_image_1_1_med_rounded',
+    'image.style.block_image_1_1_sml_rounded',
+   ];
+   _webspark_cropper_theme_update_module_config_list($configs);
+}
+
+
+/**
+ * Update specific configuration files.
+ */
+function _webspark_cropper_theme_update_module_config_list($config_list = []) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  foreach ($config_list as $config) {
+    \Drupal::service('webspark.config_manager')->updateConfigFile($config);
+  }
+  \Drupal::state()->set('configuration_locked', TRUE);
+}
+

--- a/web/modules/webspark/webspark_cropper_theme/webspark_cropper_theme.module
+++ b/web/modules/webspark/webspark_cropper_theme/webspark_cropper_theme.module
@@ -85,7 +85,8 @@ function webspark_cropper_theme_form_alter(array &$form, FormStateInterface $for
   $allowed_form_ids = [
     'media_cropped_image_rounded_1_1_edit_form',
     'media_cropped_image_rounded_1_1_add_form',
-    'media_library_add_form_upload'
+    'media_library_add_form_upload',
+    'layout_builder_update_block'
   ];
   if (in_array($form_id, $allowed_form_ids)) {
     $form['#attached']['library'][] = 'webspark_cropper_theme/rounded';

--- a/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_lge_rounded.yml
+++ b/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_lge_rounded.yml
@@ -34,8 +34,3 @@ effects:
     data:
       crop_type: 1_1_rounded
       automatic_crop_provider: null
-  ab605aed-1f13-4e39-a3bf-35c5f64c4316:
-    uuid: ab605aed-1f13-4e39-a3bf-35c5f64c4316
-    id: image_transparent_background
-    weight: 4
-    data: {  }

--- a/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_med_rounded.yml
+++ b/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_med_rounded.yml
@@ -34,8 +34,3 @@ effects:
       stroke_width: '10'
       displace: '5'
       size_correction: '-6'
-  773adba8-3eab-4070-9185-6935ac44b694:
-    uuid: 773adba8-3eab-4070-9185-6935ac44b694
-    id: image_transparent_background
-    weight: 4
-    data: {  }

--- a/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_sml_rounded.yml
+++ b/web/profiles/webspark/webspark/config/install/image.style.block_image_1_1_sml_rounded.yml
@@ -34,8 +34,3 @@ effects:
       stroke_width: '10'
       displace: '5'
       size_correction: '-6'
-  bbec67c9-c76b-479d-b9a7-beae1207398c:
-    uuid: bbec67c9-c76b-479d-b9a7-beae1207398c
-    id: image_transparent_background
-    weight: 4
-    data: {  }

--- a/web/themes/webspark/renovation/src/components/image/_images.scss
+++ b/web/themes/webspark/renovation/src/components/image/_images.scss
@@ -8,5 +8,6 @@
 
   img {
     border: 0;
+    border-radius: 100%;
   }
 }

--- a/web/themes/webspark/renovation/src/sass/layout-builder.scss
+++ b/web/themes/webspark/renovation/src/sass/layout-builder.scss
@@ -346,6 +346,15 @@
     }
   }
 
+  .uds-img-rounded {
+    border-radius: 100%;
+  
+    img {
+      border: 0;
+      border-radius: 100%;
+    }
+  }
+
 }
 
 body .ui-dialog.ui-widget.ui-widget-content.media-library-widget-modal {

--- a/web/themes/webspark/renovation/templates/media/media.html.twig
+++ b/web/themes/webspark/renovation/templates/media/media.html.twig
@@ -1,5 +1,7 @@
 {% set classes = [
-  elements['#embed'] == true ? 'embedded-media' ] %}
+  elements['#embed'] == true ? 'embedded-media' ,
+  'rounded' in content.field_media_image['#bundle']  ? 'uds-img-rounded' : '',
+  ] %}
 
   <div{{ attributes.addClass(classes) }}>
     {{ title_suffix.contextual_links }}


### PR DESCRIPTION
### Description

<!-- Description of problem -->
### Solution
Added new classes for uds-img-rounded and configs to remove transparent functionality in image styles

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1834)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
