### PR TITLE
WS2-2130-hotfix: update Parent unit fields in spin up and header block

### DIFF
--- a/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -208,20 +208,29 @@ class AsuBrandHeaderBlock extends BlockBase {
       '#title' => $this->t('Parent unit name'),
       '#description' => $this->t("(optional) Name of the ASU parent unit. Will appear above the site title. Leave blank if none."),
       '#default_value' => $config['asu_brand_header_block_parent_org'] ?? '',
-      '#states' => array(
-        'required' => array(
-          ':input[name="settings[titles][asu_brand_header_block_parent_org_url]"]' => array(
-            'filled' => TRUE,
-          ),
-        ),
-      ),
+      '#states' => [
+        'required' => [
+          ':input[name="settings[titles][asu_brand_header_block_parent_org_url]"]' => ['filled' => TRUE],
+        ],
+      ],
     ];
+
     $form['titles']['asu_brand_header_block_parent_org_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Parent department URL'),
-      '#description' => $this->t('Absolute or relative URL of the parent unit. Leave blank if none.'),
+      '#description' => $this->t('Absolute or relative URL of the parent unit.'),
       '#default_value' => $config['asu_brand_header_block_parent_org_url'] ?? '',
+      '#states' => [
+        'visible' => [
+          ':input[name="settings[titles][asu_brand_header_block_parent_org]"]' => ['filled' => TRUE],
+        ],
+        'required' => [
+          ':input[name="settings[titles][asu_brand_header_block_parent_org]"]' => ['filled' => TRUE],
+        ],
+      ],
     ];
+
+
 
 
     $form['menus'] = array(

--- a/web/profiles/webspark/webspark/modules/webspark_installer_forms/src/Form/WebsparkConfigureHeaderForm.php
+++ b/web/profiles/webspark/webspark/modules/webspark_installer_forms/src/Form/WebsparkConfigureHeaderForm.php
@@ -32,7 +32,8 @@ class WebsparkConfigureHeaderForm extends ConfigFormBase {
 
     $form['explanation'] = [
       '#markup' => '<h3>Add parent unit</h3><p>If this site is for a department/college/unit ' .
-        'that has a parent unit to be displayed in the site\'s header, enter that information below.' .
+        'that has a parent unit to be displayed in the site\'s header, enter that information below. ' .
+        'You can also add it later in the ASU brand header configuration.' .
         '<h4>Header example with Parent unit:</h4>' .
         '<img src="/profiles/webspark/webspark/modules/webspark_installer_forms/img/parent-unit-header.jpg" ' .
         'alt="Parent unit example" style="margin-top: 1rem; opacity: 0.6;" /></p>',
@@ -45,10 +46,11 @@ class WebsparkConfigureHeaderForm extends ConfigFormBase {
       '#default_value' => '',
       '#states' => [
         'required' => [
-          ':input[name="parent_department_url"]' =>['filled' => TRUE],
+          ':input[name="parent_department_url"]' => ['filled' => TRUE],
         ],
       ],
     ];
+
     $form['parent_department_url'] = [
       '#maxlength' => 255,
       '#size' => 100,
@@ -56,14 +58,19 @@ class WebsparkConfigureHeaderForm extends ConfigFormBase {
       '#type' => 'url',
       '#default_value' => '',
       '#states' => [
-        'visible' => [
+        'required' => [
           ':input[name="parent_unit_name"]' => ['filled' => TRUE],
         ],
-        'required' => [
-          ':input[name="parent_unit_name"]' =>['filled' => TRUE],
+        'visible' => [
+          ':input[name="parent_department_url"]' => ['filled' => TRUE],
+        ],
+        'visible' => [
+            ':input[name="parent_unit_name"]' => ['filled' => TRUE],
         ],
       ],
     ];
+
+
     $form['actions'] = ['#type' => 'actions'];
     $form['actions']['submit'] = [
       '#type' => 'submit',


### PR DESCRIPTION
### Description

Make Parent department URL field hidden unless Parent unit name field is filled on both site spin-up and ASU header block configuration forms. If Parent unit name field is filled, also make the Parent department URL field required, and visa versa. 

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2130)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome