### PR TITLE
WS2-2415: Remove the tabindex from the main content element

### DIFF
--- a/web/themes/webspark/renovation/templates/page/page.html.twig
+++ b/web/themes/webspark/renovation/templates/page/page.html.twig
@@ -23,7 +23,7 @@
       {% endif %}
 
       {% if page.content %}
-        <div id="skip-to-content" class="page__content center-container max-size-container" tabindex="-1">
+        <div id="skip-to-content" class="page__content center-container max-size-container">
           {{ page.content }}
         </div>
       {% endif %}


### PR DESCRIPTION
### Description

This PR removes the `tabindex="-1"` from the main content area.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2145)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
