### PR TITLE
WS2-2150: Removed innerWidth check in tabbed-panels.js

### DIFF
--- a/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
+++ b/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
@@ -25,15 +25,15 @@
     });
 
     $(".scroll-control-next").on("click", function (e) {
-      if (window.innerWidth > 992) {
+      //if (window.innerWidth > 992) {
         slideNav(this, e, -1);
-      }
+      //}
     });
 
     $(".scroll-control-prev").on("click", function (e) {
-      if (window.innerWidth > 992) {
+      //if (window.innerWidth > 992) {
         slideNav(this, e, 1);
-      }
+      //}
     });
 
     $(".uds-tabbed-panels").each(function () {

--- a/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
+++ b/web/themes/webspark/renovation/src/components/tabbed-panels/tabbed-panels.js
@@ -25,15 +25,11 @@
     });
 
     $(".scroll-control-next").on("click", function (e) {
-      //if (window.innerWidth > 992) {
-        slideNav(this, e, -1);
-      //}
+      slideNav(this, e, -1);
     });
 
     $(".scroll-control-prev").on("click", function (e) {
-      //if (window.innerWidth > 992) {
-        slideNav(this, e, 1);
-      //}
+      slideNav(this, e, 1);
     });
 
     $(".uds-tabbed-panels").each(function () {


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution 
Removed innerWidth check in tabbed-panels.js

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2150)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
