### PR TITLE
Degree pages issue

### DIFF
--- a/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
@@ -73,7 +73,7 @@ class AsuDegreePagesCreation extends ControllerBase {
         if ($node->id()) {
           $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString();
           $response = new RedirectResponse($url);
-          $response->send();
+          return $response->send();
         } else {
           \Drupal::logger('asu_degree_rfi')->error('Node creation failed or node ID is null.');
         }

--- a/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
+++ b/web/modules/webspark/asu_degree_rfi/src/Controller/AsuDegreePagesCreation.php
@@ -68,8 +68,18 @@ class AsuDegreePagesCreation extends ControllerBase {
       $node->enforceIsNew();
       $node->set('path', $path);
       $node->save();
-      $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString();
-      return (new RedirectResponse(URL::fromUserInput($url)->toString()))->send();
+
+      try {
+        if ($node->id()) {
+          $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString();
+          $response = new RedirectResponse($url);
+          $response->send();
+        } else {
+          \Drupal::logger('asu_degree_rfi')->error('Node creation failed or node ID is null.');
+        }
+      } catch (\Exception $e) {
+        \Drupal::logger('asu_degree_rfi')->error($e->getMessage());
+      }
     }
 
     return ['#markup' => $this->t('The requested page could not be found.')];


### PR DESCRIPTION
### Description

Fixes blocker to EFI-148 testing. Regression in degree pages creation. Was failing for anonymous users. 

Steps to Test:
1. verify the degree page doesn't exist in the site
2. as anonymous, click the link to that degree in a degree listing page.
3. verify the degree detail page loads
4. Also conduct steps 1-3 as a logged in user to ensure there is no regression in the other direction.
5. check the db logs. No errors should have been generated by the above actions.
6. Try creating a bogus plancode and use it in a degree URL... no page should get created for that fake degree and a message to that effect should display. The RFI form may display, and that's okay and out of scope here.
7. Try editing the plancode of a degree page to set it to a fake plancode. Save and view the degree page. The component should report that the degree is not available. If so, this passes.
