### PR TITLE
fix drop shadow on captions

### DIFF
--- a/web/profiles/webspark/webspark/config/install/field.field.block_content.image.field_image_caption.yml
+++ b/web/profiles/webspark/webspark/config/install/field.field.block_content.image.field_image_caption.yml
@@ -9,7 +9,7 @@ field_name: field_image_caption
 entity_type: block_content
 bundle: image
 label: 'Image Caption'
-description: ''
+description: 'Please note: captions are not displayed on rounded images.'
 required: false
 translatable: false
 default_value: {  }

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -536,3 +536,9 @@ function webspark_update_10004(&$sandbox) {
   }
 }
 
+function webspark_update_10005(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  \Drupal::service('webspark.config_manager')->updateConfigFile('field.field.block_content.image.field_image_caption');
+  \Drupal::state()->set('configuration_locked', TRUE);
+}
+

--- a/web/themes/webspark/renovation/src/components/block/image-block.twig
+++ b/web/themes/webspark/renovation/src/components/block/image-block.twig
@@ -1,10 +1,13 @@
 {% set style = size == "default" ? '100%' : size ~ '%' %}
+{% set is_rounded = 'rounded' in media[0]['#media'].bundle() %}
+{% set is_drop_shadow = drop_shadow[0]['#markup'] == '1' %}
+
 
 <div style="max-width: {{ style }};">
-  <div class="uds-img {{ drop_shadow[0]['#markup'] == '1' ? 'uds-img-drop-shadow' }} {{ 'rounded' in media[0]['#media'].bundle() ? 'uds-img-rounded' }}">
+  <div class="uds-img {{ is_drop_shadow ? 'uds-img-drop-shadow' : '' }} {{ is_rounded ? 'uds-img-rounded' : '' }}">
     <figure class="figure uds-figure">
       {{ media }}
-      {% if caption|render %}
+      {% if caption|render and not is_rounded %}
         <figcaption class="figure-caption uds-figure-caption">
           <span class="uds-caption-text">
             {{ caption }}

--- a/web/themes/webspark/renovation/src/components/image/_images.scss
+++ b/web/themes/webspark/renovation/src/components/image/_images.scss
@@ -1,6 +1,19 @@
 // Add margin to bottom of an image with a box shadow
-.uds-img.uds-img-drop-shadow {
-  margin-bottom: 1rem;
+
+.uds-img {
+  &.uds-img-drop-shadow {
+    margin-bottom: 1rem;
+  }
+  &.uds-img-drop-shadow.uds-img-rounded {
+    margin-bottom: 1rem;
+    box-shadow: unset;
+
+    .uds-img-rounded {
+      img {
+        box-shadow: 0 0.5rem 1rem rgba(25, 25, 25, 0.2);
+      }
+    }
+  }
 }
 
 .uds-img-rounded {

--- a/web/themes/webspark/renovation/src/sass/layout-builder.scss
+++ b/web/themes/webspark/renovation/src/sass/layout-builder.scss
@@ -136,6 +136,7 @@
   }
 
   .description {
+    display: block;
     &.text-muted {
       color: inherit !important;
     }
@@ -348,7 +349,7 @@
 
   .uds-img-rounded {
     border-radius: 100%;
-  
+
     img {
       border: 0;
       border-radius: 100%;


### PR DESCRIPTION
### Description
I have adjusted the CSS to apply the drop shadow to the image itself. This solves the problem. I also have added a border to the top of the caption box, a shadow to the caption, and a margin between the image and the caption box.

QA: 
- Check if the rounded image has a drop shadow that does not go outside the image itself.
- In the edit form, the caption field should have help text that indicates that captions will not display for rounded images.
- Set a caption in the edit form and verify that it does not display
- Make sure that existing drop shadows on rectangular images still display correctly (no regressions)

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2143)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu) 
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
