### PR TITLE
WS2-2106: Add patch to apply fix for insert media dialog focus

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -1,7 +1,8 @@
 {
     "drupal/core": {
         "#2951547: Fix issue with layout overflow": "https://www.drupal.org/files/issues/2022-07-13/f245f21ea664f22c81d8d28c6f0f4a42fb9a5890.patch",
-        "3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2024-05-16/core-10.2.3-xss-refactor_filter_attributes-3109650-74.patch"
+        "3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2024-05-16/core-10.2.3-xss-refactor_filter_attributes-3109650-74.patch",
+        "#3415961: Fix issue with focus after inserting media via the modal dialog": "https://www.drupal.org/files/issues/2024-02-15/3415961.patch"
     },
     "drupal/config_readonly": {
         "#3085001: Config blacklist to only block some configuration while in read only mode": "https://www.drupal.org/files/issues/2019-10-31/config_readonly-3085001-2.patch"


### PR DESCRIPTION
### Description

Currently, when users use the add media button from the CKE toolbar, after choosing an image the focus automatically shifts to the save button for the content. This is disruptive (especially on long pages) as the user will need to scroll back to their last position to continue editing content. 

This PR applies a patch to ensure that after the media is added, the focus shifts to the media itself.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2106)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
- [ ] Safari
- [ ] Firefox
