### PR TITLE
Remove role=“link” from a tag

### DIFF
--- a/web/themes/webspark/renovation/src/components/buttons/button-action.twig
+++ b/web/themes/webspark/renovation/src/components/buttons/button-action.twig
@@ -3,7 +3,6 @@
     href="{{ url }}"
     class="btn {{ button_color }}"
     target="{{ target }}"
-    role="link"
     data-ga-event="link"
     data-ga-action="click"
     data-ga-name="onclick"


### PR DESCRIPTION
A11y role=“link” is not needed as <a> role is already a link

### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/uds-1683)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
