### PR TITLE
WS2-1707: Update the Site URL field to be optional

### DIFF
--- a/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -199,9 +199,9 @@ class AsuBrandHeaderBlock extends BlockBase {
     $form['titles']['asu_brand_header_block_base_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Site URL'),
-      '#description' => $this->t("URL of this site's home page."),
-      '#default_value' => $config['asu_brand_header_block_base_url'] ?? $this->getBaseUrl(),
-      '#required' => TRUE
+      '#description' => $this->t("(optional) Only use this if you need to specify a subsite URL. Leave blank if none."),
+      '#default_value' => $config['asu_brand_header_block_base_url'] ?? '',
+      '#required' => FALSE
     ];
     $form['titles']['asu_brand_header_block_parent_org'] = [
       '#type' => 'textfield',

--- a/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/web/modules/webspark/asu_brand/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -199,7 +199,7 @@ class AsuBrandHeaderBlock extends BlockBase {
     $form['titles']['asu_brand_header_block_base_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Site URL'),
-      '#description' => $this->t("(optional) Only use this if you need to specify a subsite URL. Leave blank if none."),
+      '#description' => $this->t("(optional) Only use if you need to specify a subsite URL. Leave blank to use the current site URL."),
       '#default_value' => $config['asu_brand_header_block_base_url'] ?? '',
       '#required' => FALSE
     ];


### PR DESCRIPTION
### Description

This PR makes the "Site URL" field found in the ASU Brand Header block settings optional, and makes a small change to the fields' description.

Currently, the field is required, but the user does not manually input the URL during the site creation process. The URL is automatically set to the current sites' domain. This becomes a problem for sites that do not have a parent unit because it is common for the site to be built on the DEV or TEST environment, and this current process will save that environments' domain in the configs. After the site is launched LIVE, the user must remember to manually update the URL in this field to the new URL.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1707)

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
