### PR TITLE
WS2-2154: Update People Results in the Webdir admin UI

### DIFF
--- a/web/modules/webspark/webspark_webdir/js/asurite-field.js
+++ b/web/modules/webspark/webspark_webdir/js/asurite-field.js
@@ -125,11 +125,13 @@
 
     $(data).each(function (i, element) {
       if (element.asurite_id) {
-        var new_element = {};
+        let new_element = {};
         let title = element.title;
         new_element.id = element.asurite_id + ':' + element.dept_id;
-        new_element.text = element.display_name + ', ' + element.asurite_id +
-                  ', ' + element.dept_name + ', ' + title;
+        let nameHandler = element.display_name ? ', ' + element.display_name : '';
+        let deptHandler = element.dept_name ? ', ' + element.dept_name : '';
+        let titleHandler = title ? ', ' + title : '';
+        new_element.text = element.asurite_id + nameHandler + titleHandler + deptHandler;
         new_element.type = "person";
         result.push(new_element);
       }


### PR DESCRIPTION
### Description

The big work for this ticket has to be done in SCHWEB. It is in [SCHWEB-1275](https://asudev.jira.com/browse/SCHWEB-1275). This pull request only fixes the logic to remove the extra commas if no display name, title, or department is provided. This will make for a more sustainable interface, regardless of whether some data exists for display.

QA Steps:

- Navigate to /node/31/layout and click the pencil icon to open the Off Canvas dialog for the “People” section.
- Under “Profiles” you should see a list of the profiles that have been selected for display. They should display as the following:
  - asurite id, display name, department name, title. If any of those items are missing, you should not see a trailing comma.
- If this is the case, it passes.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2154)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
