### PR TITLE
WS2-2175: Fix layout builder .form-actions z-index to be above hero content

### DIFF
--- a/web/themes/webspark/renovation/src/sass/layout-builder.scss
+++ b/web/themes/webspark/renovation/src/sass/layout-builder.scss
@@ -361,7 +361,7 @@ body .ui-dialog.ui-widget.ui-widget-content.media-library-widget-modal {
     position: fixed;
     bottom: 0;
     left: calc(50% - 400px);
-    z-index: 10;
+    z-index: 31;
     align-items: baseline;
     border-radius: 20px 20px 0 0;
     width: 800px;


### PR DESCRIPTION
### Description

The Layout Builder form actions buttons currently go below the content of hero images.

We need to increase the z-index value so that the form actions buttons are above the hero image content.

QA Steps:

- Log and navigate to the Kitchen Sink page
- Click on the “Layout” tab to load layout builder
- Scroll past the hero image. If the buttons now display above the hero content (text, background shadow, and buttons), then this passes.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2175)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
