### PR TITLE
WS2-2208: Removed h4 tag and wrapper span in p for accesibility on donut.twig

### DIFF
--- a/web/themes/webspark/renovation/src/components/charts-and-graphs/donut.twig
+++ b/web/themes/webspark/renovation/src/components/charts-and-graphs/donut.twig
@@ -3,8 +3,10 @@
 
 <div class="uds-charts-and-graphs-container" data-number="{{ number }}">
   <div class="uds-charts-and-graphs-overlay {{ text_color }}">
-    <h4 id="percentage-display">{{ number }}%</h4>
-    <span>{{ text }}</span>
+    <p id="percentage-display">
+      {{ number }}%<br>
+      <span>{{ text }}</span>
+    </p>
   </div>
   <canvas id="uds-donut"></canvas>
 </div>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution 
Removed h4 tag and wrapper span in p for accesibility on donut.twig

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2208)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
