### PR TITLE
WS2-2200: Changed h4 to h2 on anchor-menu and added js

### DIFF
--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -8,7 +8,7 @@
           return;
         }
 
-        let section = $('.uds-anchor-menu-wrapper h4').text().toLowerCase().trim();
+        let section = $('.uds-anchor-menu-wrapper h2').text().toLowerCase().trim();
 
         $(once('append-anchor-menu-items', links, context)).each(function(i, item) {
           let icon = $(item).siblings('.anchor-link-icon').html();

--- a/web/modules/webspark/webspark_blocks/templates/webspark-blocks-anchor-menu.html.twig
+++ b/web/modules/webspark/webspark_blocks/templates/webspark-blocks-anchor-menu.html.twig
@@ -1,9 +1,9 @@
 <div id="uds-anchor-menu" class="uds-anchor-menu uds-anchor-menu-expanded-lg" style="display: none;">
   <div class="container">
     <div class="uds-anchor-menu-wrapper">
-      <h4 data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+      <h2 data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
         {{ 'On This Page:'|t }} <svg class="svg-inline--fa fa-chevron-down fa-w-14" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"></path></svg><!-- <span class="fas fa-chevron-down"></span> -->
-      </h4>
+      </h2>
       <div id="collapseExample" class="collapse">
         <nav class="nav" aria-label="Same Page"></nav>
       </div>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution 
Changed h4 to h2 on anchor-menu and added js

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2200)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
