### PR TITLE
WS2-2214: Remove the "Add new module" button

### DIFF
--- a/web/modules/webspark/webspark_utility/src/Routing/RouteSubscriber.php
+++ b/web/modules/webspark/webspark_utility/src/Routing/RouteSubscriber.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\webspark_utility\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+class RouteSubscriber extends RouteSubscriberBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Always deny access to '/admin/modules/install'
+    if ($route = $collection->get('update.module_install')) {
+      // Note that the second parameter of setRequirement() is a string, not a boolean
+      $route->setRequirement('_access', 'FALSE');
+    }
+  }
+}

--- a/web/modules/webspark/webspark_utility/webspark_utility.services.yml
+++ b/web/modules/webspark/webspark_utility/webspark_utility.services.yml
@@ -1,4 +1,8 @@
 services:
   webspark.config_manager:
     class: Drupal\webspark_utility\WebsparkUtilityConfigManager
-    arguments: ['@entity_type.manager', '@config.storage', '@config_update.extension_storage', '@config_update.config_update', '@module_handler', '@config.factory']
+    arguments: [ '@entity_type.manager', '@config.storage', '@config_update.extension_storage', '@config_update.config_update', '@module_handler', '@config.factory' ]
+  webspark.route_subscriber:
+    class: Drupal\webspark_utility\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
### Description

This PR adds a route subscriber to remove access to the `update.module_install` route.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2214)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge
