### PR TITLE
WS2-2171: Anchor menu duplication in sticky menu after every update inside admin

### DIFF
--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -11,7 +11,7 @@
         let section = $('.uds-anchor-menu-wrapper h4').text().toLowerCase().trim();
 
         // If the user is an admin, we clear the anchor menu items to not duplicate links
-        if(drupalSettings.is_admin) {
+        if (drupalSettings.is_admin) {
           $(once('clear-anchor-menu-items', '#uds-anchor-menu .nav', context)).each(function() {
             $('#uds-anchor-menu .nav').empty();
           });

--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -10,6 +10,13 @@
 
         let section = $('.uds-anchor-menu-wrapper h4').text().toLowerCase().trim();
 
+        // If the user is an admin, we clear the anchor menu items to not duplicate links
+        if(drupalSettings.is_admin) {
+          $(once('clear-anchor-menu-items', '#uds-anchor-menu .nav', context)).each(function() {
+            $('#uds-anchor-menu .nav').empty();
+          });
+        }
+
         $(once('append-anchor-menu-items', links, context)).each(function(i, item) {
           let icon = $(item).siblings('.anchor-link-icon').html();
           let title = $(item).data('title');


### PR DESCRIPTION
### Description

The anchor menu duplicates in the sticky menu after every anchor menu update inside layout builder admin.

QA Steps:

- navigate to https://pr-544-webspark-ci.ws.asu.edu/anchor-menu
- navigate to edit in layout builder
- create a new block, + Create content block, and create a Text Content block
- after adding block admin title and some formatted text, under Appearance Settings, create an Anchor menu title and select an icon for it, and finally click Add block
- Check that the newly created Anchor menu item has been added and that the entire anchor menu isn't being duplicated
- Attempt drag and dropping the associated Anchor content to another place on the page to make sure the Anchor menu resorts items appropriately 
- Save layout and make sure anchor menu functions as expected

 
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2171)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update

### Verified in browsers 

- [x] Chrome
- [x] Safari
