### PR TITLE
WS2-2260: Make button text required for Image Based cards

### DIFF
--- a/web/profiles/webspark/webspark/config/install/field.field.paragraph.image_based_card.field_link.yml
+++ b/web/profiles/webspark/webspark/config/install/field.field.paragraph.image_based_card.field_link.yml
@@ -17,6 +17,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 2
   link_type: 17
 field_type: link

--- a/web/profiles/webspark/webspark/config/install/field.field.paragraph.image_based_card.field_link.yml
+++ b/web/profiles/webspark/webspark/config/install/field.field.paragraph.image_based_card.field_link.yml
@@ -11,7 +11,7 @@ field_name: field_link
 entity_type: paragraph
 bundle: image_based_card
 label: 'Card Link'
-description: ''
+description: 'Link text is required, as it will be used for accessibility purposes.'
 required: false
 translatable: true
 default_value: {  }

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -542,3 +542,11 @@ function webspark_update_10005(&$sandbox) {
   \Drupal::state()->set('configuration_locked', TRUE);
 }
 
+/**
+ * Makes Image Based Card link text required.
+ */
+function webspark_update_10010(&$sandbox) {
+  \Drupal::state()->set('configuration_locked', FALSE);
+  \Drupal::service('webspark.config_manager')->updateConfigFile('field.field.paragraph.image_based_card.field_link');
+  \Drupal::state()->set('configuration_locked', TRUE);
+}


### PR DESCRIPTION
### Description

This PR makes the link text in Image Based Cards required. It also adds help text.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2260)

### Checklist

- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [x] Chrome

### Screenshots
![Screenshot 2024-08-20 at 2 55 32 PM](https://github.com/user-attachments/assets/3cc5fb75-c250-49c5-94d3-ae87b21e2001)


