### PR TITLE
WS2-2269: Fix error checking on the Webspark Config Refresh drush command

### DIFF
--- a/web/modules/webspark/webspark_utility/src/Drush/Commands/WebsparkUtilityCommands.php
+++ b/web/modules/webspark/webspark_utility/src/Drush/Commands/WebsparkUtilityCommands.php
@@ -45,7 +45,9 @@ final class WebsparkUtilityCommands extends DrushCommands {
     $date = new \DateTime();
     $now = $date->getTimestamp();
     $getBackupDate = exec('terminus backup:info webspark-release-stable.dev --element=db --format=php 2>&1', $backupOutput);
-    if (in_array('[37;41m  You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.  [39;49m', $backupOutput)) {
+    // Check if user is logged in.
+    $backupOutputArray = array_map(fn($i) => str_contains($i, 'You are not logged in'), $backupOutput);
+    if (in_array(true, $backupOutputArray, true)) {
       $this->logger()->error('Your DDEV instance is currently not logged in to Pantheon via terminus.' . PHP_EOL .
         '  Please run `ddev ssh` and then run `terminus auth:login --machine-token=$TERMINUS_MACHINE_TOKEN; exit` to authenticate.');
       return;


### PR DESCRIPTION
### Description
The login checking was insufficient and not catching things. I have updated it so that it works more reliably.

QA steps:
1. Pull this branch to your local machine and create a DDEV container (if you don't already have one)
2. Make sure that you are not logged into terminus within DDEV. To to this, run `ddev ssh` and then run `terminus auth:logout` and then exit from the ssh session
3. Run the drush command: `ddev drush wcr`
4. The command should sense that you aren't logged in and should provide an error message in the terminal that says:
```
[error]  Your DDEV instance is currently not logged in to Pantheon via terminus.
Please run `ddev ssh` and then run `terminus auth:login --machine-token=$TERMINUS_MACHINE_TOKEN; exit` to authenticate.
```
5. If the error shows up, this passes.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2269)
