### PR TITLE
WS2-2278: Load the correct image size for the component

### DIFF
--- a/web/modules/webspark/webspark_blocks/webspark_blocks.module
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.module
@@ -1,7 +1,8 @@
 <?php
 
 use Drupal\block_content\BlockContentInterface;
-use  \Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\image\Entity\ImageStyle;
 
 function webspark_blocks_theme_suggestions_block_alter(array &$suggestions, array $variables) {
 
@@ -208,4 +209,18 @@ function webspark_blocks_config_readonly_whitelist_patterns() {
   else {
     return [];
   }
+}
+
+/**
+ * Load the correct image size for Hover Cards.
+ *
+ * Implements hook_preprocess_paragraph().
+ *
+ * @param $variables
+ *
+ * @return void
+ */
+function webspark_blocks_preprocess_paragraph__hover_card(&$variables): void {
+  $media = $variables['content']['field_media'][0]['#media']->field_media_image->entity;
+  $variables['hoverCardImageUrl'] = ImageStyle::load('block_image_16_25_lge')->buildUrl($media->getFileUri());
 }

--- a/web/themes/webspark/renovation/templates/paragraphs/paragraph--hover-card.html.twig
+++ b/web/themes/webspark/renovation/templates/paragraphs/paragraph--hover-card.html.twig
@@ -3,7 +3,7 @@
     <div class="content-section text-white my-2">
       <div class="image-holder">
         <img
-          src="{{ file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value) }}"
+          src="{{ hoverCardImageUrl }}"
           alt="{{ content.field_media[0]['#media'].field_media_image.alt }}"
           loading="lazy"
           decoding="async"


### PR DESCRIPTION
### Description

In further testing of the new Hover Cards block, I noticed the wrong image was being loaded. This PR adds a hook to load the correct (cropped) image.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2278)

### QA

- Create a Basic Page and add a Hover Card block via the Layout Builder
- Ensure that the image used for the block on the front end is the cropped image, and not the original image

### Checklist

- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket

### Verified in browsers 

- [x] Chrome
