### PR TITLE
WS2-2153: Pagination: Mobile positioning not always correct

### DIFF
--- a/web/modules/webspark/webspark_module_views_pager/templates/asu-pager-nav.html.twig
+++ b/web/modules/webspark/webspark_module_views_pager/templates/asu-pager-nav.html.twig
@@ -1,0 +1,138 @@
+<nav class="my-4" role="navigation" aria-labelledby="pagination-heading">
+    <h4 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h4>
+    {% if color == 'default' %}
+      <ul class="pagination pager__items js-pager__items {{ alignment }}{% if border %} border p-2{% endif %}">
+    {% else%}
+      <ul class="pagination pager__items js-pager__items {{ alignment }} {{ color }} p-2">
+    {% endif%}
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="page-item pager__item pager__item--previous">
+          <a
+              href="{{ items.previous.href }}"
+              title="{{ 'Go to previous page'|t }}"
+              rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}
+              class="page-link{{ page_link_icon }}"
+              data-ga-event="select"
+              data-ga-action="click"
+              data-ga-name="onclick"
+              data-ga-type="pagination"
+              data-ga-region="main content"
+              data-ga-section="pagination"
+              data-ga-text="prev">
+          </a>
+        </li>
+      {% endif %}
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if ellipses.previous and (show_ellipses == true) %}
+
+        <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
+      {% endif %}
+      {# Show first page and ellipsis if first page not shown in pages. #}
+      {% if show_last == true %}
+        {% if items.pages.1 is not defined %}
+          <li class="page-item pager__item">
+            <a
+              href="{{ items.first.href }}"
+              title="{{ 'Go to first page'|t }}"
+              class="page-link"
+              data-ga-event="select"
+              data-ga-action="click"
+              data-ga-name="onclick"
+              data-ga-type="pagination"
+              data-ga-region="main content"
+              data-ga-section="pagination"
+              data-ga-text="page 1">
+              1
+            </a>
+          </li>
+          {# Don't show first elipsis if 2nd page is available in pages array #}
+          {% if page_two == false %}
+            <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
+          {% endif %}
+        {% endif %}
+      {% endif %}
+
+      {# Now generate the actual pager piece. #}
+      {% for key, item in items.pages %}
+        <li class="page-item pager__item{% if show_active %}{{ current == key ? ' is-active active' : '' }} {% endif %}">
+          {% if current == key %}
+            {% set title = 'Current page'|t %}
+          {% else %}
+            {% set title = 'Go to page @key'|t({'@key': key}) %}
+          {% endif %}
+          <a
+            href="{{ item.href }}"
+            title="{{ title }}"{{ item.attributes|without('href', 'title') }}
+            class="page-link"
+            data-ga-event="select"
+            data-ga-action="click"
+            data-ga-name="onclick"
+            data-ga-type="pagination"
+            data-ga-region="main content"
+            data-ga-section="pagination"
+            data-ga-text="{{ 'page @key'|t({'@key': key}) }}">
+            <span class="visually-hidden">
+              {{ current == key ? 'Current page'|t : 'Page'|t }}
+            </span>
+            {{- key -}}
+          </a>
+        </li>
+      {% endfor %}
+      {# Show last page and ellipsis if last page not shown in pages. #}
+      {% if show_last == true %}
+        {# Don't print the last element twice #}
+        {% set page_keys = items.pages|keys %}
+        {% if last_page not in page_keys %}
+          <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
+          <li class="page-item pager__item">
+            <a
+              href="{{ items.last.href }}"
+              title="{{ 'Go to last page'|t }}"
+              class="page-link"
+              data-ga-event="select"
+              data-ga-action="click"
+              data-ga-name="onclick"
+              data-ga-type="pagination"
+              data-ga-region="main content"
+              data-ga-section="pagination"
+              data-ga-text="{{ last_page }}">
+              {{ last_page }}
+            </a>
+          </li>
+        {% endif %}
+      {% endif %}
+
+
+      {% if items.current and (items.previous or items.next) %}
+        <li class="page-item disabled">
+          {% trans %}
+            <span class="page-link">Page {{ items.current }}</span>
+          {% endtrans %}
+        </li>
+      {% endif %}
+
+      {# Add an ellipsis if there are further next pages. #}
+      {% if ellipses.next and (show_ellipses == true) %}
+        <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
+      {% endif %}
+        {# Print next item if we are not on the last page. #}
+        {% if items.next %}
+          <li class="page-item">
+            <a
+              href="{{ items.next.href }}"
+              title="{{ 'Go to next page'|t }}"
+              rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}
+              class="page-link{{ page_link_icon }}"
+              data-ga-event="select"
+              data-ga-action="click"
+              data-ga-name="onclick"
+              data-ga-type="pagination"
+              data-ga-region="main content"
+              data-ga-section="pagination"
+              data-ga-text="next">
+            </a>
+          </li>
+        {% endif %}
+    </ul>
+  </nav>

--- a/web/modules/webspark/webspark_module_views_pager/templates/asu-pager.html.twig
+++ b/web/modules/webspark/webspark_module_views_pager/templates/asu-pager.html.twig
@@ -28,13 +28,13 @@
 {# DESKTOP #}
 {% set items = desktop.items %}
 {% set ellipses = desktop.ellipses %}
-<div class="d-sm-none d-md-block">
+<div class="d-none d-lg-block">
   {% include '@webspark_module_views_pager/templates/asu-pager-nav.html.twig' %}
 </div>
 {# MOBILE #}
 {% set items = mobile.items %}
 {% set ellipses = mobile.ellipses %}
-<div class="d-none d-sm-block d-md-none">
+<div class="d-lg-none">
   {% if items %}
     {% include '@webspark_module_views_pager/templates/asu-pager-nav.html.twig' %}
   {% endif %}

--- a/web/modules/webspark/webspark_module_views_pager/templates/asu-pager.html.twig
+++ b/web/modules/webspark/webspark_module_views_pager/templates/asu-pager.html.twig
@@ -25,143 +25,17 @@
 {% else %}
   {% set page_link_icon = '' %}
 {% endif %}
-{% if items %}
-  <nav class="my-4" role="navigation" aria-labelledby="pagination-heading">
-    <h4 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h4>
-    {% if color == 'default' %}
-      <ul class="pagination pager__items js-pager__items {{ alignment }}{% if border %} border p-2{% endif %}">
-    {% else%}
-      <ul class="pagination pager__items js-pager__items {{ alignment }} {{ color }} p-2">
-    {% endif%}
-      {# Print previous item if we are not on the first page. #}
-      {% if items.previous %}
-        <li class="page-item pager__item pager__item--previous">
-          <a 
-              href="{{ items.previous.href }}" 
-              title="{{ 'Go to previous page'|t }}"
-              rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}
-              class="page-link{{ page_link_icon }}"
-              data-ga-event="select"
-              data-ga-action="click"
-              data-ga-name="onclick"
-              data-ga-type="pagination"
-              data-ga-region="main content"
-              data-ga-section="pagination"
-              data-ga-text="prev">
-          </a>
-        </li>
-      {% endif %}
-      {# Add an ellipsis if there are further previous pages. #}
-      {% if ellipses.previous and (show_ellipses == true) %}
-
-        <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
-      {% endif %}
-      {# Show first page and ellipsis if first page not shown in pages. #}
-      {% if show_last == true %}
-        {% if items.pages.1 is not defined %}
-          <li class="page-item pager__item">
-            <a 
-              href="{{ items.first.href }}" 
-              title="{{ 'Go to first page'|t }}"
-              class="page-link"
-              data-ga-event="select"
-              data-ga-action="click"
-              data-ga-name="onclick"
-              data-ga-type="pagination"
-              data-ga-region="main content"
-              data-ga-section="pagination"
-              data-ga-text="page 1">
-              1
-            </a>
-          </li>
-          {# Don't show first elipsis if 2nd page is available in pages array #}
-          {% if page_two == false %}
-            <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-
-      {# Now generate the actual pager piece. #}
-      {% for key, item in items.pages %}
-        <li class="page-item pager__item{% if show_active %}{{ current == key ? ' is-active active' : '' }} {% endif %}">
-          {% if current == key %}
-            {% set title = 'Current page'|t %}
-          {% else %}
-            {% set title = 'Go to page @key'|t({'@key': key}) %}
-          {% endif %}
-          <a 
-            href="{{ item.href }}" 
-            title="{{ title }}"{{ item.attributes|without('href', 'title') }} 
-            class="page-link"
-            data-ga-event="select"
-            data-ga-action="click"
-            data-ga-name="onclick"
-            data-ga-type="pagination"
-            data-ga-region="main content"
-            data-ga-section="pagination"
-            data-ga-text="{{ 'page @key'|t({'@key': key}) }}">
-            <span class="visually-hidden">
-              {{ current == key ? 'Current page'|t : 'Page'|t }}
-            </span>
-            {{- key -}}
-          </a>
-        </li>
-      {% endfor %}
-      {# Show last page and ellipsis if last page not shown in pages. #}
-      {% if show_last == true %}
-        {# Don't print the last element twice #}
-        {% set page_keys = items.pages|keys %}
-        {% if last_page not in page_keys %}
-          <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
-          <li class="page-item pager__item">
-            <a 
-              href="{{ items.last.href }}" 
-              title="{{ 'Go to last page'|t }}"
-              class="page-link"
-              data-ga-event="select"
-              data-ga-action="click"
-              data-ga-name="onclick"
-              data-ga-type="pagination"
-              data-ga-region="main content"
-              data-ga-section="pagination"
-              data-ga-text="{{ last_page }}">
-              {{ last_page }}
-            </a>
-          </li>
-        {% endif %}
-      {% endif %}
-
-
-      {% if items.current and (items.previous or items.next) %}
-        <li class="page-item disabled">
-          {% trans %}
-            <span class="page-link">Page {{ items.current }}</span>
-          {% endtrans %}
-        </li>
-      {% endif %}
-
-      {# Add an ellipsis if there are further next pages. #}
-      {% if ellipses.next and (show_ellipses == true) %}
-        <li class="page-item elipses" role="presentation"><span class="page-link">&hellip;</span></li>
-      {% endif %}
-        {# Print next item if we are not on the last page. #}
-        {% if items.next %}
-          <li class="page-item">
-            <a 
-              href="{{ items.next.href }}" 
-              title="{{ 'Go to next page'|t }}"
-              rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}
-              class="page-link{{ page_link_icon }}"
-              data-ga-event="select"
-              data-ga-action="click"
-              data-ga-name="onclick"
-              data-ga-type="pagination"
-              data-ga-region="main content"
-              data-ga-section="pagination"
-              data-ga-text="next">
-            </a>
-          </li>
-        {% endif %}
-    </ul>
-  </nav>
-{% endif %}
+{# DESKTOP #}
+{% set items = desktop.items %}
+{% set ellipses = desktop.ellipses %}
+<div class="d-sm-none d-md-block">
+  {% include '@webspark_module_views_pager/templates/asu-pager-nav.html.twig' %}
+</div>
+{# MOBILE #}
+{% set items = mobile.items %}
+{% set ellipses = mobile.ellipses %}
+<div class="d-none d-sm-block d-md-none">
+  {% if items %}
+    {% include '@webspark_module_views_pager/templates/asu-pager-nav.html.twig' %}
+  {% endif %}
+</div>

--- a/web/modules/webspark/webspark_module_views_pager/webspark_module_views_pager.module
+++ b/web/modules/webspark/webspark_module_views_pager/webspark_module_views_pager.module
@@ -82,8 +82,58 @@ function template_preprocess_asu_pager(&$variables) {
     return;
   }
 
-  $tags = $variables['tags'];
 
+  // Initialize the pager for 'desktop' with dynamic page quantity
+  $variables = _webspark_module_views_pager_init_pager('desktop',$quantity, $element, $variables, $pager, $pager_max, $pager_manager, $route_name, $route_parameters, $parameters);
+  // Initialize the pager for 'mobile' with a fixed 3-page limit
+  $variables = _webspark_module_views_pager_init_pager('mobile', 3, $element, $variables, $pager, $pager_max, $pager_manager, $route_name, $route_parameters, $parameters);
+
+
+  // $variables['items'] = $items;
+  $variables['last_page'] = $pager_max;
+  $variables['heading_id'] = Html::getUniqueId('pagination-heading');
+
+  // The rendered link needs to play well with any other query parameter used
+  // on the page, like exposed filters, so for the cacheability all query
+  // parameters matter.
+  $variables['#cache']['contexts'][] = 'url.query_args';
+}
+
+/**
+ * Initialize pager variables for the given scope.
+ *
+ * @param string $scope
+ *   The scope of the pager, either "desktop" or "mobile".
+ * @param int $quantity
+ *   The number of pages in the pager.
+ * @param int $element
+ *   The element ID of the pager.
+ * @param array $variables
+ *   An associative array containing:
+ *   - tags: An array of labels for the controls in the pager.
+ *   - parameters: An associative array of query string parameters to append
+ *     to the pager links.
+ *   - route_name: The route name of the pager.
+ *   - route_parameters: An associative array of the route parameters.
+ * @param \Drupal\Core\Pager\PagerInterface $pager
+ *   The pager object.
+ * @param int $pager_max
+ *   The total number of pages in the pager.
+ * @param \Drupal\Core\Pager\PagerManagerInterface $pager_manager
+ *   The pager manager service.
+ * @param string $route_name
+ *   The route name of the pager.
+ * @param array $route_parameters
+ *   An associative array of the route parameters.
+ * @param array $parameters
+ *   An associative array of query string parameters to append to the pager
+ *   links.
+ *
+ * @return array
+ *   The initialized pager variables.
+ */
+function _webspark_module_views_pager_init_pager($scope, $quantity, $element, $variables, $pager, $pager_max, $pager_manager, $route_name, $route_parameters, $parameters) {
+  $tags = $variables['tags'];
   // Calculate various markers within this pager piece:
   // Middle is used to "center" pages around the current page.
   $pager_middle = ceil($quantity / 2);
@@ -147,7 +197,7 @@ function template_preprocess_asu_pager(&$variables) {
     }
     // Add an ellipsis if there are further next pages.
     if ($i < $pager_max + 1) {
-      $variables['ellipses']['next'] = TRUE;
+      $variables[$scope]['ellipses']['next'] = TRUE;
     }
   }
 
@@ -182,12 +232,7 @@ function template_preprocess_asu_pager(&$variables) {
     }
   }
 
-  $variables['items'] = $items;
-  $variables['last_page'] = $pager_max;
-  $variables['heading_id'] = Html::getUniqueId('pagination-heading');
+  $variables[$scope]['items'] = $items;
 
-  // The rendered link needs to play well with any other query parameter used
-  // on the page, like exposed filters, so for the cacheability all query
-  // parameters matter.
-  $variables['#cache']['contexts'][] = 'url.query_args';
+  return $variables;
 }


### PR DESCRIPTION
### Description

#### Description of problem 
On mobile, if the pagination is large enough that the user has to use the horizontal scrolling, the pagination does not always display correctly. Sometimes on page load, the active page is not visible in the pagination, and other times the active page pagination item is cut off the pagination container.
#### Solution 
Add functionality to differentiate mobile pagination limit

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2153)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
