### PR TITLE
WS2-1829: CKEditor 5: Layout options in editor dropdown need to be more compact

### DIFF
--- a/web/modules/webspark/webspark_ckeditor_plugins/css/websparkplugin.css
+++ b/web/modules/webspark/webspark_ckeditor_plugins/css/websparkplugin.css
@@ -47,3 +47,8 @@ form .webspark-blockquote-dialog input.ck-input {
 form .webspark-liststyle-dialog {
   width: 250px !important;
 }
+
+.ck-list > .ck-list__item > button {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}


### PR DESCRIPTION


### Description

#### Description of problem
CKEditor 5: Layout options in editor dropdown need to be more compact
#### Solution 
Removed padding top and botton from buttons on ckeditor list dropdown

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1829)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
