### PR TITLE
WS2-2348 : Changed h2 color on blockquote animated

### DIFF
--- a/web/themes/webspark/renovation/src/components/blockquote/_blockquote.scss
+++ b/web/themes/webspark/renovation/src/components/blockquote/_blockquote.scss
@@ -30,6 +30,10 @@
     color: #191919;
   }
 
+  mark {
+    color: #191919;
+  }
+
   a {
     color: $black;
   }

--- a/web/themes/webspark/renovation/src/components/blockquote/_blockquote.scss
+++ b/web/themes/webspark/renovation/src/components/blockquote/_blockquote.scss
@@ -27,6 +27,7 @@
     letter-spacing: -.14rem;
     line-height: 4.25rem;
     max-width: 100%;
+    color: #191919;
   }
 
   a {


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Changed h2 color on blockquote animated

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2348)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
