### PR TITLE
WS2-2290: Added if to check empty Heading

### DIFF
--- a/web/themes/webspark/renovation/src/components/cards/card-arrangement.twig
+++ b/web/themes/webspark/renovation/src/components/cards/card-arrangement.twig
@@ -1,6 +1,8 @@
 <div class="uds-card-arrangement {{ class_layout }}">
   <div class="uds-card-arrangement-content-container {{ text_color }}">
-    <h2>{{ heading }}</h2>
+    {% if heading['#title'] is not empty %}
+      <h2>{{ heading }}</h2>
+    {% endif %}
     {{ text }}
     {{ cta }}
   </div>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution 
Added if to check empty Heading

### QA Steps

1. Create or edit a Basic Page.
2. Add or edit a Card Arrangement in the Layout section.
3. In the Main Content panel, leave the Heading field blank.
4. Inspect the final result and confirm that the empty `<h2>` tag has disappeared.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2290)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
