### PR TITLE
WS2-2297: All Custom Blocks: H1 heading text is focusable, but shouldn't be

### DIFF
--- a/web/themes/webspark/renovation/src/components/headings/heading.twig
+++ b/web/themes/webspark/renovation/src/components/headings/heading.twig
@@ -6,6 +6,6 @@
   {% set classes = classes|merge(['article']) %}
 {% endif %}
 
-<{{ html_tag }}{{ classes|length > 0 ? attributes.addClass(classes) }} tabindex="0">
+<{{ html_tag }}{{ classes|length > 0 ? attributes.addClass(classes) }} {{ html_tag == 'h1' ? '' : 'tabindex="0"' }}>
   {{ heading }}
 </{{ html_tag }}>

--- a/web/themes/webspark/renovation/src/components/headings/heading.twig
+++ b/web/themes/webspark/renovation/src/components/headings/heading.twig
@@ -6,6 +6,6 @@
   {% set classes = classes|merge(['article']) %}
 {% endif %}
 
-<{{ html_tag }}{{ classes|length > 0 ? attributes.addClass(classes) }} {{ html_tag == 'h1' ? '' : 'tabindex="0"' }}>
+<{{ html_tag }}{{ classes|length > 0 ? attributes.addClass(classes) }}>
   {{ heading }}
 </{{ html_tag }}>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution 
Added a condition to remove `tabindex="0"` from `<h1>` headings.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2297)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
