### PR TITLE
WS2-2324: Testimonial on Image Background: background image is missing alt text

### DIFF
--- a/web/themes/webspark/renovation/src/components/quote-image-background/quote-image-background.twig
+++ b/web/themes/webspark/renovation/src/components/quote-image-background/quote-image-background.twig
@@ -16,7 +16,8 @@
 {# NOTE: The Testimonial markup is not correct and needs to be adjusted to match UDS #}
 <div
   class="uds-quote-image-background"
-  style="background-image: linear-gradient(rgba(25, 25, 25, 0) 0%, rgba(25, 25, 25, 0.79) 100%), url({{ image }});">
+  style="background-image: linear-gradient(rgba(25, 25, 25, 0) 0%, rgba(25, 25, 25, 0.79) 100%), url({{ image }});"
+  aria-label="{{ aria_label }}">
   <div class="uds-content-align">
     {{ testimonial }}
   </div>

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial-on-image-background.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--testimonial-on-image-background.html.twig
@@ -22,6 +22,7 @@
   {% block content %}
     {% include '@renovation/quote-image-background/quote-image-background.twig' with {
       image: file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value),
+      aria_label: content.field_media[0]['#media'].field_media_image.alt,
       testimonial: content.field_testimonial_component,
     } %}
     {{ content|without('field_accent_color', 'field_heading_highlight', 'field_media', 'field_text_color', 'field_testimonial_component', 'field_anchor_menu_settings') }}


### PR DESCRIPTION
…image div in Testimonial.

### Description

<!-- Description of problem -->
#### Solution 
Added functionality to set an aria-label on the background image div in Testimonial

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2324)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
