### PR TITLE
WS2-1788: Refactoring Image gallery form

### DIFF
--- a/web/profiles/webspark/webspark/config/install/core.entity_form_display.block_content.gallery.default.yml
+++ b/web/profiles/webspark/webspark/config/install/core.entity_form_display.block_content.gallery.default.yml
@@ -21,7 +21,7 @@ third_party_settings:
       label: 'Appearance Settings'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 4
       format_type: tab
       format_settings:
         classes: ''
@@ -30,15 +30,15 @@ third_party_settings:
         description: ''
         required_fields: true
     group_help_text:
-      children:
-        - field_carousel_card
+      children: {  }
       label: 'Note: All carousel images have to be the same aspect ratio.'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 1
       format_type: html_element
       format_settings:
         classes: ''
+        show_empty_fields: true
         id: ''
         element: H3
         show_label: true
@@ -91,7 +91,7 @@ content:
     third_party_settings: {  }
   field_tooltip:
     type: entity_reference_paragraphs
-    weight: 4
+    weight: 3
     region: content
     settings:
       title: Paragraph

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -749,3 +749,15 @@ function webspark_update_10013(&$sandbox): void{
 
   \Drupal::state()->set('configuration_locked', TRUE);
 }
+
+/**
+ * WS2-1788 - Update block content gallery display
+ */
+function webspark_update_10014(&$sandbox): void{
+  \Drupal::state()->set('configuration_locked', FALSE);
+
+  //Update block content gallery display
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_form_display.block_content.gallery.default');
+
+  \Drupal::state()->set('configuration_locked', TRUE);
+}


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Refactoring Image gallery form

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1788)

### QA Steps

1. Enter [Image gallery](https://pr-622-webspark-ci.ws.asu.edu/image-gallery)
2. Edit the layout
3. Edit the Image Gallery block
4. Inspect the "Note: All carousel images have to be the same aspect ratio." and verify that the `h3` tag had only the `note` 
6. Verify that the form matches the appearance of other forms.

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
