### PR TITLE
WS2-2324: Add conditional to render aria-label only when it has content

### DIFF
--- a/web/themes/webspark/renovation/src/components/quote-image-background/quote-image-background.twig
+++ b/web/themes/webspark/renovation/src/components/quote-image-background/quote-image-background.twig
@@ -17,7 +17,9 @@
 <div
   class="uds-quote-image-background"
   style="background-image: linear-gradient(rgba(25, 25, 25, 0) 0%, rgba(25, 25, 25, 0.79) 100%), url({{ image }});"
-  aria-label="{{ aria_label }}">
+  {% if aria_label is not empty %}
+    aria-label="{{ aria_label }}"
+  {% endif %}>
   <div class="uds-content-align">
     {{ testimonial }}
   </div>


### PR DESCRIPTION


### Description

<!-- Description of problem -->
#### Solution
Prevent rendering of empty aria-label attribute using conditional in Twig

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2324)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
