### PR TITLE
WS2-2440: Update outdated Behat tests

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -729,6 +729,50 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Check for ellipses when pagination items exceed a threshold.
+   *
+   * @Then I should see ellipses if pagination items are greater than :threshold
+   *
+   * @param int $threshold
+   *
+   * @return void
+   * @throws Exception
+   */
+  public function checkElipsesExistsWithPagination(int $threshold): void {
+    $lastPageElement = $this->getSession()
+      ->getPage()
+      ->find('css', '.page-item:nth-last-child(2) > .page-link');
+
+    if (NULL === $lastPageElement) {
+      throw new Exception('last pagination element not found.');
+    }
+
+    $totalPages = (int) filter_var($lastPageElement->getText(), FILTER_SANITIZE_NUMBER_INT);
+
+    // Check if pagination exceeds threshold
+    if ($totalPages > $threshold) {
+      // There is a typo in Drupal for the class name, it should be "ellipsis" instead of "elipses"
+      $element = $this->getSession()
+        ->getPage()
+        ->find('css', 'li.page-item.elipses > span.page-link');
+      if (NULL === $element) {
+        throw new Exception(sprintf(
+          'Ellipses not found when pagination count (%d) exceeds threshold (%d)',
+          $totalPages,
+          $threshold
+        ));
+      }
+    }
+    else {
+      echo sprintf(
+        'Pagination count (%d) does not exceed threshold (%d), skipping ellipses check',
+        $totalPages,
+        $threshold
+      );
+    }
+  }
+
+  /**
    * Check bullet list styles.
    *
    * @Then I should see the bullet list styles are correct on :selector

--- a/features/ckeditor-buttons.feature
+++ b/features/ckeditor-buttons.feature
@@ -14,6 +14,12 @@ Feature: CKEditor button verification
     Then I should see that the "[data-cke-tooltip-text^='Italic']" element exists
     # Link button
     Then I should see that the "[data-cke-tooltip-text^='Link']" element exists
+    # Unordered list button
+    Then I should see that the "[data-cke-tooltip-text='Bulleted List']" element exists
+    # Ordered list button
+    Then I should see that the "[data-cke-tooltip-text='Numbered List']" element exists
+    # Disabled list styles button
+    Then I should see that the "[data-cke-tooltip-text='List Properties']" element exists
     # Fontawesome button
     Then I should see that the "[data-cke-tooltip-text='Insert Fontawesome Icon']" element exists
     # Upload image button
@@ -26,12 +32,6 @@ Feature: CKEditor button verification
     Then I should see that the "[data-cke-tooltip-text='Source']" element exists
     # Responsive columns button
     Then I should see that the "[data-cke-tooltip-text='CKEditor Responsive']" element exists
-    # Unordered list button
-    Then I should see that the "[data-cke-tooltip-text='Bulleted List']" element exists
-    # Ordered list button
-    Then I should see that the "[data-cke-tooltip-text='Numbered List']" element exists
-    # Disabled list styles button
-    Then I should see that the "[data-cke-tooltip-text='List Properties']" element exists
     # Button button
     Then I should see that the "[data-cke-tooltip-text='Button']" element exists
     # Horizontal line button
@@ -44,5 +44,9 @@ Feature: CKEditor button verification
     Then I should see that the "[data-cke-tooltip-text='Highlighted Heading']" element exists
     # Blockquote button
     Then I should see that the "[data-cke-tooltip-text='Blockquote']" element exists
+    # Animated Bliockquote
+    Then I should see that the "[data-cke-tooltip-text='Blockquote Animated']" element exists
+    # Highlight
+    Then I should see that the "[data-cke-tooltip-text='Highlight']" element exists
     # Webspark table button
     Then I should see that the "[data-cke-tooltip-text='Webspark table']" element exists

--- a/features/ckeditor-buttons.feature
+++ b/features/ckeditor-buttons.feature
@@ -6,14 +6,8 @@ Feature: CKEditor button verification
   @api @javascript
   Scenario: Verify CKEditor buttons
     Given I am logged in as user "admin"
-    When I am at '/node/28/layout'
-    Then I scroll ".layout__region--first" into view
+    When I am at '/node/add/page'
     Then I wait for 2 seconds
-    Then I hover over the element ".block-inline-blocktext-content"
-    Then I press "Open Text Content configuration options"
-    # Configure link
-    Then I click the element ".block-inline-blocktext-content ul > li:nth-child(1) > a"
-    Then I wait for 1 second
     # Bold button
     Then I should see that the "[data-cke-tooltip-text^='Bold']" element exists
     # Italics button
@@ -52,5 +46,3 @@ Feature: CKEditor button verification
     Then I should see that the "[data-cke-tooltip-text='Blockquote']" element exists
     # Webspark table button
     Then I should see that the "[data-cke-tooltip-text='Webspark table']" element exists
-
-

--- a/features/pagination.feature
+++ b/features/pagination.feature
@@ -11,9 +11,9 @@ Feature: Pagination
     # Current/active page should be page 1.
     Then I should see that the "li.page-item.pager__item.is-active.active" element exists
     And I should see that the "li.page-item.active > a[title='Current page'][data-ga-text='page 1']" element exists
-    # Next button exists with chevron (it says "last page," but that's a mistake).
+    # Button to visit the last page of items should exist.
     And I should see that the "li.page-item > a[title='Go to last page']" element exists
-#    And I should see the link "Next"
+    # Button to visit the next page of items should exist.
     And I should see the chevron icon exists on the "li.page-item > a[title='Go to next page']" pager item
     # Click page 2.
     When I click the element "li.page-item > a[title='Go to page 2']"
@@ -24,8 +24,8 @@ Feature: Pagination
     # "Prev" button now displays with chevron.
     And I should see that the "li.page-item > a[title='Go to previous page']" element exists
     And I should see the chevron icon exists on the "li.page-item > a[title='Go to previous page']" pager item
-    # A total of 13 items should display ("<" plus 10 pages, the ellipses, and ">")
-    Then I should see that 13 of "ul.pagination.pager__items li.page-item" elements exist
+    # Check for ellipses.
+    And I should see ellipses if pagination items are greater than 9
     # Click "Next".
     When I click the element "li.page-item > a[title='Go to next page']"
     # Page 3 should be active/current.
@@ -34,7 +34,3 @@ Feature: Pagination
     When I click the element "li.page-item > a[title='Go to previous page']"
     # Page 2 should be active/current again.
     Then I should see that the "li.page-item.active > a[title='Current page'][data-ga-text='page 2']" element exists
-
-
-
-


### PR DESCRIPTION
### Description

A few Behat tests were failing because they are too specific, so any small changes in content will break them. I update these particular tests to be more generic but still adequately test the desired functionality. Other tests will need these changes, but those will be addressed as they come up.

The pagination test still requires us to add a threshold, but is now more flexible and easier to match whatever the view setting is. The test will now skip the check if it is not needed.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2440)

### Checklist

- [x] QA steps to verify have been included on the Jira ticket

### Screenshots

<img width="747" alt="Screenshot 2024-11-07 at 10 49 33 AM" src="https://github.com/user-attachments/assets/585f9736-b830-410d-bd11-1040ce2ea4b2">

