### PR TITLE
WS2-2419: Added aria-label and alt for card-and-image.twig

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,1 +1,2 @@
 api_version: 1
+php_version: 8.3

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,2 +1,1 @@
 api_version: 1
-php_version: 8.3

--- a/web/themes/webspark/renovation/src/components/cards/card-and-image-parallax.twig
+++ b/web/themes/webspark/renovation/src/components/cards/card-and-image-parallax.twig
@@ -5,7 +5,10 @@ TODO: This markup is not correct, but it is not a component we can just copy fro
 For now, we will use CSS to bring it inline, but we will want to re-work this markup soon.
 #}
 <section class="parallax-container">
-  <img src="{{ image_background }}" loading="lazy" decoding="async" fetchpriority="high" />
+  <img src="{{ image_background }}" loading="lazy" decoding="async" fetchpriority="high"
+    {% if image_alt is not empty %}
+    alt="{{ image_alt }}"
+    {% endif %}/>
   <div class="parallax-container-content uds-card-and-image {{ class_position }}">
     <div class="uds-content-align">
       <div class="uds-card-and-image-container">

--- a/web/themes/webspark/renovation/src/components/cards/card-and-image.twig
+++ b/web/themes/webspark/renovation/src/components/cards/card-and-image.twig
@@ -1,4 +1,7 @@
 <div
+  {% if image_alt is not empty %}
+    aria-label="{{ image_alt }}"
+  {% endif %}
   class="uds-card-and-image {{ class_position }}"
   style="background-image: linear-gradient(rgba(25, 25, 25, 0) 0%, rgba(25, 25, 25, 0.79) 100%), url({{ image_background }});">
   <div class="uds-content-align card-and-image-align">

--- a/web/themes/webspark/renovation/templates/block/block--inline-block--card-and-image.html.twig
+++ b/web/themes/webspark/renovation/templates/block/block--inline-block--card-and-image.html.twig
@@ -29,6 +29,7 @@
   {% block content %}
     {% include '@renovation/cards/' ~ template with {
       image_background: file_url(content.field_media[0]['#media'].field_media_image.entity.uri.value),
+      image_alt: content.field_media[0]['#media'].field_media_image.alt,
       card: content.field_card,
     } %}
   {% endblock %}


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Added aria-label and alt for card-and-image.twig

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2419)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
