### PR TITLE
WS2-2466 remove jquery from header initialization script

### DIFF
--- a/web/modules/asu_modules/asu_brand/js/asu_brand.header.js
+++ b/web/modules/asu_modules/asu_brand/js/asu_brand.header.js
@@ -1,4 +1,4 @@
-(function ($, Drupal, drupalSettings) {
+(function (Drupal, drupalSettings) {
   // Not using behaviors for most of this.
   Drupal.behaviors.AsuBrandHeaderBehavior = {
     attach: function (context, settings) {
@@ -173,6 +173,4 @@
     }
   }
 
-// TODO Without jQuery, we get Uncaught ReferenceError: jQuery is not defined.
-// Is it required by Drupal or drupalSettings? Would like it working w/o jQuery.
-})(jQuery, Drupal, drupalSettings);
+})(Drupal, drupalSettings);


### PR DESCRIPTION
### Description

Removes unneeded jQuery load-in for header initialization.

### Steps to test
1. Visit PR site and ensure the header loads.
2. Login. Make sure the header stays loaded.
3. Check the console log for errors related to the header JS initialization - specifically `Uncaught ReferenceError: jQuery is not defined`.
4. Clear the cache. Is the header still around?

If all those check out, this works as defined.

Bonus points, you could do a performance test using https://pagespeed.web.dev/ and comparing the PR site with our current sprint site and check to for improvements. Before this update:

![Screenshot 2024-11-14 at 4 49 55 PM](https://github.com/user-attachments/assets/3d2a1b91-8ef6-4a67-9be7-b5f56723b86d)

Note: This isn't the only JS being loaded, so it's possible some other code is loading jQuery, if it shows up in the scan. But at least we've stopped requiring it for every instance of the header and reduced the likelihood of it being added.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2466)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

