### PR TITLE
WS2-2423: Added style for min-height and min-width for a tags in breadcrumb

### DIFF
--- a/web/themes/webspark/renovation/src/components/breadcrumb/_breadcrumb.scss
+++ b/web/themes/webspark/renovation/src/components/breadcrumb/_breadcrumb.scss
@@ -1,0 +1,9 @@
+.breadcrumb-item {
+  min-height: 24px;
+  min-width: 24px;
+
+  a {
+    min-height: 24px;
+    min-width: 24px;
+  }
+}

--- a/web/themes/webspark/renovation/src/components/breadcrumb/_breadcrumb.scss
+++ b/web/themes/webspark/renovation/src/components/breadcrumb/_breadcrumb.scss
@@ -5,5 +5,6 @@
   a {
     min-height: 24px;
     min-width: 24px;
+    display: flex;
   }
 }

--- a/web/themes/webspark/renovation/src/sass/components/_index.scss
+++ b/web/themes/webspark/renovation/src/sass/components/_index.scss
@@ -1,5 +1,6 @@
 @import "../../components/accordions/accordions";
 @import "../../components/blockquote/blockquote";
+@import "../../components/breadcrumb/breadcrumb";
 @import "../../components/cards/card-and-image-parallax";
 @import "../../components/cards/card-and-image";
 @import "../../components/cards/card-arrangements";


### PR DESCRIPTION


### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2423)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
