### PR TITLE
WS2 1329: Layout Builder UI Notice - FIeld states UI notice in drupal log when adding a webdir block via layout builder

### DIFF
--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -9,7 +9,9 @@
         "#3085001: Config blacklist to only block some configuration while in read only mode": "https://www.drupal.org/files/issues/2019-10-31/config_readonly-3085001-2.patch"
     },
     "drupal/field_states_ui": {
-        "#3225009: Cant add custom block with field states ui using layout builder": "https://www.drupal.org/files/issues/2023-06-21/3225009-6.patch"
+        "#3225009: Cant add custom block with field states ui using layout builder": "https://www.drupal.org/files/issues/2023-06-21/3225009-6.patch",
+        "#3371927: PluginNotFoundException: The \"\" plugin does not exist": "upstream-configuration/patches/field_states_ui_3371927_mr_10.patch",
+        "3442166: Unable to change either the Target or Comparison elements": "https://www.drupal.org/files/issues/2024-09-27/resolve_fields_states_ui.patch"
     },
     "drupal/linkit": {
         "2877535: Fix issue with path alias": "https://www.drupal.org/files/issues/2023-10-05/linkit-2877535-64.patch"

--- a/upstream-configuration/patches/field_states_ui_3371927_mr_10.patch
+++ b/upstream-configuration/patches/field_states_ui_3371927_mr_10.patch
@@ -1,0 +1,27 @@
+From c4b8790af6a10a1a12e49573a290c0917cdfc0e0 Mon Sep 17 00:00:00 2001
+From: Jo Fitzgerald <20467-jofitz@users.noreply.drupalcode.org>
+Date: Fri, 19 Apr 2024 17:27:13 +0000
+Subject: [PATCH] Include type as a hidden form element to ake it available in
+ $form_state
+
+---
+ src/FieldStateManager.php | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/FieldStateManager.php b/src/FieldStateManager.php
+index 3db119b..768bad2 100644
+--- a/src/FieldStateManager.php
++++ b/src/FieldStateManager.php
+@@ -414,6 +414,9 @@ class FieldStateManager extends DefaultPluginManager {
+         $title = t('Add new field state: @type', ['@type' => $field_state->label()]);
+         $submit_label = t('Add');
+         $op = 'new';
++
++        $element['form']['type']['#type'] = 'hidden';
++        $element['form']['type']['#title'] = $type;
+       }
+       $element['form']['edit'] = $field_state->buildConfigurationForm([], $form_state);
+       $element['form']['edit']['#type'] = 'fieldset';
+-- 
+GitLab
+

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddPeopleWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddPeopleWidget.php
@@ -30,6 +30,10 @@ class WebdirAddPeopleWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-add-people')),
       '#prefix' => '<div id="asurite-add-people-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAddWidget.php
@@ -30,6 +30,10 @@ class WebdirAddWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-add')),
       '#prefix' => '<div id="asurite-add-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAsuriteWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirAsuriteWidget.php
@@ -30,6 +30,10 @@ class WebdirAsuriteWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-tree')),
       '#prefix' => '<div id="asurite-tree-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirCampusWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirCampusWidget.php
@@ -30,6 +30,10 @@ class WebdirCampusWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('campus-tree')),
       '#prefix' => '<div id="campus-tree-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
 
     // Add the required libraries.

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirDepartmentsWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirDepartmentsWidget.php
@@ -30,6 +30,10 @@ class WebdirDepartmentsWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('directory-tree')),
       '#prefix' => '<div id="directory-tree-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
 
     // Add the required libraries.

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirEmployeeTypeWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirEmployeeTypeWidget.php
@@ -30,6 +30,10 @@ class WebdirEmployeeTypeWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('employee-type-tree')),
       '#prefix' => '<div id="employee-type-tree-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
 
     // Add the required libraries.

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirExpertiseWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirExpertiseWidget.php
@@ -30,6 +30,10 @@ class WebdirExpertiseWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('expertise-tree')),
       '#prefix' => '<div id="expertise-tree-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
 
     // Add the required libraries.

--- a/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirListWidget.php
+++ b/web/modules/webspark/webspark_webdir/src/Plugin/Field/FieldWidget/WebdirListWidget.php
@@ -30,6 +30,10 @@ class WebdirListWidget extends WidgetBase {
       '#default_value' => $value,
       '#attributes' => array('class' => array('asurite-list')),
       '#prefix' => '<div id="asurite-list-options" style="width: 100%" class="ck-reset"></div>',
+      '#field_parents' => [
+        0 => 'settings',
+        1 => 'block_form',
+      ],
     ];
     // Add the required libraries.
     $element['#attached']['library'][] = 'webspark_webdir/jstree';


### PR DESCRIPTION
### Description

Using Xdebug, I found that all of the other elements that used the field_states API had a `#field_parents` array in their field definition. So, I added that to all of our widgets, and it solved the problem. While I was in there, I added a couple of patches to make field_states_ui work better. They were my first attempt to fix things, but while they improved the overall experience, they didn't alleviate the notice messages regarding `#field_parents`. So, they are a little scope-creepy, but not too bad. We needed them anyway.

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1329)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update


Note: Sections that are not applicable for this issue can be removed.
