### PR TITLE
WS2-2507: Update webspark version numbers

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -68,5 +68,5 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.14.2"
+    "version": "2.15.0"
 }

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -2,7 +2,7 @@ name: Webspark
 type: profile
 core_version_requirement: ^9.0 || ^10
 description: 'ASU custom profile.'
-version: 2.14.2
+version: 2.15.0
 distribution:
   name: 'Webspark'
 install:


### PR DESCRIPTION
### Description

This PR updates the webspark version numbers to 2.15.0.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2507)
