### PR TITLE
WS2-2307: Webform: confusing error message ARIA label for text fields

### DIFF
--- a/web/themes/webspark/renovation/includes/form.inc
+++ b/web/themes/webspark/renovation/includes/form.inc
@@ -28,6 +28,13 @@ function renovation_preprocess_input__submit(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function renovation_preprocess_input(&$variables) {
+  $variables['attributes']['aria-describedby'][] = 'error-' . $variables['attributes']['name'];
+}
+
+/**
  * Add description text to media item dialogs regarding Remote Videos.
  * Add additional fields for configuring media items of type 'image'.
  *

--- a/web/themes/webspark/renovation/includes/form.inc
+++ b/web/themes/webspark/renovation/includes/form.inc
@@ -5,6 +5,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Template\Attribute;
 
 function renovation_form_alter(&$form, &$form_state, $form_id) {
   // Add classes to cancel button on Layout Builder discard/revert changes.
@@ -32,6 +33,17 @@ function renovation_preprocess_input__submit(&$variables) {
  */
 function renovation_preprocess_input(&$variables) {
   $variables['attributes']['aria-describedby'][] = 'error-' . $variables['attributes']['name'];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function renovation_preprocess_textarea(&$variables) {
+  if (!isset($variables['attributes']) || !($variables['attributes'] instanceof Attribute)) {
+    $variables['attributes'] = new Attribute();
+  }
+
+  $variables['attributes']->setAttribute('aria-describedby', 'error-' . $variables['attributes']['name']);
 }
 
 /**

--- a/web/themes/webspark/renovation/templates/form/form-element.html.twig
+++ b/web/themes/webspark/renovation/templates/form/form-element.html.twig
@@ -59,7 +59,6 @@
     'form-group',
   ]
 %}
-{% set id_test = 'testId' %}
 {%
   set description_classes = [
     'description',

--- a/web/themes/webspark/renovation/templates/form/form-element.html.twig
+++ b/web/themes/webspark/renovation/templates/form/form-element.html.twig
@@ -59,6 +59,7 @@
     'form-group',
   ]
 %}
+{% set id_test = 'testId' %}
 {%
   set description_classes = [
     'description',
@@ -87,7 +88,8 @@
     {{ label }}
   {% endif %}
   {% if errors %}
-    <small class="invalid-feedback">
+    {% set id = 'error-' ~ name|clean_class %}
+    <small class="invalid-feedback" id="{{ id }}">
       <span title="Alert" class="fa fa-icon fa-exclamation-triangle"></span>
       {{ errors }}
     </small>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
This PR improves accessibility by adding aria-describedby attributes to <input> and <textarea> elements. This allows screen readers (such as VoiceOver) to properly associate error messages with their respective form fields, enhancing the user experience for visually impaired users.

**Changes Implemented**
Added _aria-describedby_ in _hook_preprocess_input()_

Ensures that all <input> elements include an aria-describedby attribute referencing the corresponding error message container.
This helps screen readers announce validation errors when users navigate through form fields.
Example:
`<input name="email" aria-describedby="error-email">
`Added aria-describedby in hook_preprocess_textarea()

Similar to the input fields, this ensures <textarea> elements include the aria-describedby attribute for accessibility improvements.
Uses Attribute::setAttribute() to properly assign the ID dynamically.
Updated Template to Generate Unique Error Message IDs

Generates a unique error ID using name|clean_class to avoid invalid characters.
Example:
twig

```
{% set id = 'error-' ~ name|clean_class %}
<small class="invalid-feedback" id="{{ id }}">Error message here</small>
```
Why This Matters?
Improved Screen Reader Support: Screen readers will now correctly announce validation errors by associating them with the corresponding fields.
Better Compliance with WCAG (Web Content Accessibility Guidelines): This change aligns with accessibility best practices.
Consistent Error Handling: Ensures error messages are dynamically linked to form elements across different input types.
Before & After Example
Before (Missing aria-describedby)
html

```
<input name="email">
<small class="invalid-feedback" id="error-email">Invalid email</small>
```
Screen readers would not associate the error message with the input field.

After (With aria-describedby)
html

```
<input name="email" aria-describedby="error-email">
<small class="invalid-feedback" id="error-email">Invalid email</small>
```
Now, screen readers will correctly announce the error when the input is focused.
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2307)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
