### PR TITLE
fix mono-package-split.yml

### DIFF
--- a/.github/workflows/mono-package-split.yml
+++ b/.github/workflows/mono-package-split.yml
@@ -82,7 +82,7 @@ jobs:
           GITHUB_TOKEN: x-access-token:${{ steps.app-token.outputs.token }}
         with:
           tag: ${GITHUB_REF#refs/tags/}
-          package_directory: 'web/modules/asu_modules/${{ matrix.package.local_path }}'
+          package_directory: '${{ matrix.package.local_path }}'
           repository_organization: ASUWebPlatforms
           repository_name: '${{ matrix.package.split_repository }}'
           user_name: ws2-release-bot


### PR DESCRIPTION
I discovered that the monorepo deployment didn't work when we released WS2.15.1. This should fix that problem.
