### PR TITLE
ACMN 52: Migrate user1 with an ASURITE to a different account and disable user1 

### DIFF
--- a/.github/workflows/mono-package-split.yml
+++ b/.github/workflows/mono-package-split.yml
@@ -34,6 +34,8 @@ jobs:
             split_repository: asu_react_integration
           - local_path: web/modules/asu_modules/asu_config_utility
             split_repository: asu_config_utility
+          - local_path: web/modules/asu_modules/asu_secure_superadmin
+            split_repository: asu_secure_superadmin
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +53,7 @@ jobs:
           # This app allows us to select all of the repositories we will be adding
           # our access permissions to via the app-token. Just list them below
           # in a comma separated string (without any spaces).
-          repositories: 'asu_user,asu_brand,asu_react_core,asu_react_integration,asu_config_utility'
+          repositories: 'asu_user,asu_brand,asu_react_core,asu_react_integration,asu_config_utility,asu_secure_superadmin'
 
       # The danharrin/monorepo-split-github-action below is the tool that we are using
       # to sync the contents of the modules into their respective standalone,

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
         "asu_modules/asu_config_utility": "self.version",
         "asu_modules/asu_react_core": "self.version",
         "asu_modules/asu_react_integration": "self.version",
-        "asu_modules/asu_user": "self.version"
+        "asu_modules/asu_user": "self.version",
+        "asu_modules/asu_secure_superadmin": "self.version"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb373116e17b80813494723a653222e2",
+    "content-hash": "1f461cc6a3812affcd1ac26641f91821",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1953,8 +1953,8 @@
                     "version": "1.0.2",
                     "datestamp": "1695740655",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
                     }
                 }
             },
@@ -1963,10 +1963,6 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
-                {
-                    "name": "dczepierga",
-                    "homepage": "https://www.drupal.org/user/911466"
-                },
                 {
                     "name": "hass",
                     "homepage": "https://www.drupal.org/user/85918"
@@ -1984,12 +1980,8 @@
                     "homepage": "https://www.drupal.org/user/1078742"
                 },
                 {
-                    "name": "Magnus",
+                    "name": "magnus",
                     "homepage": "https://www.drupal.org/user/73919"
-                },
-                {
-                    "name": "mkesicki",
-                    "homepage": "https://www.drupal.org/user/922884"
                 },
                 {
                     "name": "nod_",
@@ -2004,7 +1996,7 @@
                     "homepage": "https://www.drupal.org/user/2793801"
                 },
                 {
-                    "name": "Wim Leers",
+                    "name": "wim leers",
                     "homepage": "https://www.drupal.org/user/99777"
                 },
                 {
@@ -3582,10 +3574,10 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/fontawesome.git",
-                "reference": "11fe4956a46ba2ca431d320cf0773a74eba9086e"
+                "reference": "171f1a5446af878654d0f6a6547cddf6230dfc77"
             },
             "require": {
-                "drupal/core": "^9.4 || ^10"
+                "drupal/core": "^10.2 || ^11.0"
             },
             "type": "drupal-module",
             "extra": {
@@ -3593,8 +3585,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.26+7-dev",
-                    "datestamp": "1726361922",
+                    "version": "8.x-2.26+9-dev",
+                    "datestamp": "1737494928",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -3602,7 +3594,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10 || ^11"
+                        "drush.services.yml": "^12 || ^13"
                     }
                 }
             },
@@ -3612,7 +3604,7 @@
             ],
             "authors": [
                 {
-                    "name": "Daniel.Moberly",
+                    "name": "daniel.moberly",
                     "homepage": "https://www.drupal.org/user/1160788"
                 },
                 {
@@ -6174,16 +6166,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v11.38.2",
+            "version": "v11.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "9100b083eeb85d38d78fc1de28f7326596ab2eda"
+                "reference": "6fd628d32a0989211c4f2829bf0a6a6175b2f3fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/9100b083eeb85d38d78fc1de28f7326596ab2eda",
-                "reference": "9100b083eeb85d38d78fc1de28f7326596ab2eda",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/6fd628d32a0989211c4f2829bf0a6a6175b2f3fd",
+                "reference": "6fd628d32a0989211c4f2829bf0a6a6175b2f3fd",
                 "shasum": ""
             },
             "require": {
@@ -6226,11 +6218,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-12-18T14:14:45+00:00"
+            "time": "2025-02-05T10:23:21+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v11.38.2",
+            "version": "v11.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -6276,16 +6268,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v11.38.2",
+            "version": "v11.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "534b697fc1dd9fbdd9fbf2f33fc9dcbb943dea75"
+                "reference": "b350a3cd8450846325cb49e1cbc1293598b18898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/534b697fc1dd9fbdd9fbf2f33fc9dcbb943dea75",
-                "reference": "534b697fc1dd9fbdd9fbf2f33fc9dcbb943dea75",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/b350a3cd8450846325cb49e1cbc1293598b18898",
+                "reference": "b350a3cd8450846325cb49e1cbc1293598b18898",
                 "shasum": ""
             },
             "require": {
@@ -6320,11 +6312,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-01-10T20:57:00+00:00"
+            "time": "2025-02-10T14:20:57+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v11.38.2",
+            "version": "v11.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -6985,11 +6977,11 @@
         },
         {
             "name": "pantheon-upstreams/upstream-configuration",
-            "version": "2.14.2",
+            "version": "2.15.1",
             "dist": {
                 "type": "path",
                 "url": "upstream-configuration",
-                "reference": "8df818be123e80a6b993f37e70def16adb7ecb9f"
+                "reference": "0eb43fea73e2fbccaa6822eb3c4d6867d0d0cc25"
             },
             "require": {
                 "composer/installers": "v2.0.0",
@@ -8372,16 +8364,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.17",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "37ad2380e8c1a8cf62a1200a5c10080b679b446c"
+                "reference": "e8d3b5b1975e67812a54388b1ba8e9ec28eb770e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/37ad2380e8c1a8cf62a1200a5c10080b679b446c",
-                "reference": "37ad2380e8c1a8cf62a1200a5c10080b679b446c",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/e8d3b5b1975e67812a54388b1ba8e9ec28eb770e",
+                "reference": "e8d3b5b1975e67812a54388b1ba8e9ec28eb770e",
                 "shasum": ""
             },
             "require": {
@@ -8427,7 +8419,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.17"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -8443,7 +8435,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-06T13:30:51+00:00"
+            "time": "2025-01-06T09:38:16+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -8733,16 +8725,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.16",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "431771b7a6f662f1575b3cfc8fd7617aa9864d57"
+                "reference": "d0492d6217e5ab48f51fca76f64cf8e78919d0db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/431771b7a6f662f1575b3cfc8fd7617aa9864d57",
-                "reference": "431771b7a6f662f1575b3cfc8fd7617aa9864d57",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d0492d6217e5ab48f51fca76f64cf8e78919d0db",
+                "reference": "d0492d6217e5ab48f51fca76f64cf8e78919d0db",
                 "shasum": ""
             },
             "require": {
@@ -8790,7 +8782,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.16"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -8806,20 +8798,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T18:58:10+00:00"
+            "time": "2025-01-09T15:48:56+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.17",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c5647393c5ce11833d13e4b70fff4b571d4ac710"
+                "reference": "fca7197bfe9e99dfae7fb1ad3f7f5bd9ef80e1b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c5647393c5ce11833d13e4b70fff4b571d4ac710",
-                "reference": "c5647393c5ce11833d13e4b70fff4b571d4ac710",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fca7197bfe9e99dfae7fb1ad3f7f5bd9ef80e1b7",
+                "reference": "fca7197bfe9e99dfae7fb1ad3f7f5bd9ef80e1b7",
                 "shasum": ""
             },
             "require": {
@@ -8904,7 +8896,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.17"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -8920,20 +8912,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-31T14:49:31+00:00"
+            "time": "2025-01-29T07:25:58+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.4.13",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "c2f7e0d8d7ac8fe25faccf5d8cac462805db2663"
+                "reference": "e93a6ae2767d7f7578c2b7961d9d8e27580b2b11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/c2f7e0d8d7ac8fe25faccf5d8cac462805db2663",
-                "reference": "c2f7e0d8d7ac8fe25faccf5d8cac462805db2663",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/e93a6ae2767d7f7578c2b7961d9d8e27580b2b11",
+                "reference": "e93a6ae2767d7f7578c2b7961d9d8e27580b2b11",
                 "shasum": ""
             },
             "require": {
@@ -8984,7 +8976,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.4.13"
+                "source": "https://github.com/symfony/mailer/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -9000,20 +8992,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2025-01-24T15:27:15+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.17",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "ea87c8850a54ff039d3e0ab4ae5586dd4e6c0232"
+                "reference": "917d77981eb1ea963608d5cda4d9c0cf72eaa68e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/ea87c8850a54ff039d3e0ab4ae5586dd4e6c0232",
-                "reference": "ea87c8850a54ff039d3e0ab4ae5586dd4e6c0232",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/917d77981eb1ea963608d5cda4d9c0cf72eaa68e",
+                "reference": "917d77981eb1ea963608d5cda4d9c0cf72eaa68e",
                 "shasum": ""
             },
             "require": {
@@ -9069,7 +9061,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.17"
+                "source": "https://github.com/symfony/mime/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -9085,7 +9077,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-02T11:09:41+00:00"
+            "time": "2025-01-23T13:10:52+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -10013,16 +10005,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.16",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "91e02e606b4b705c2f4fb42f7e7708b7923a3220"
+                "reference": "e9bfc94953019089acdfb9be51c1b9142c4afa68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/91e02e606b4b705c2f4fb42f7e7708b7923a3220",
-                "reference": "91e02e606b4b705c2f4fb42f7e7708b7923a3220",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/e9bfc94953019089acdfb9be51c1b9142c4afa68",
+                "reference": "e9bfc94953019089acdfb9be51c1b9142c4afa68",
                 "shasum": ""
             },
             "require": {
@@ -10076,7 +10068,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.16"
+                "source": "https://github.com/symfony/routing/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -10092,20 +10084,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T15:31:34+00:00"
+            "time": "2025-01-09T08:51:02+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.15",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "9d862d66198f3c2e30404228629ef4c18d5d608e"
+                "reference": "6ad986f62276da4c8c69754decfaa445a89cb6e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/9d862d66198f3c2e30404228629ef4c18d5d608e",
-                "reference": "9d862d66198f3c2e30404228629ef4c18d5d608e",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/6ad986f62276da4c8c69754decfaa445a89cb6e3",
+                "reference": "6ad986f62276da4c8c69754decfaa445a89cb6e3",
                 "shasum": ""
             },
             "require": {
@@ -10174,7 +10166,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.15"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -10190,7 +10182,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-23T13:25:59+00:00"
+            "time": "2025-01-28T18:47:02+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -10441,16 +10433,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v6.4.17",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "a3c19a0e542d427c207e22242043ef35b5b99a2c"
+                "reference": "ce20367d07b2592202e9c266b16a93fa50145207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/a3c19a0e542d427c207e22242043ef35b5b99a2c",
-                "reference": "a3c19a0e542d427c207e22242043ef35b5b99a2c",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/ce20367d07b2592202e9c266b16a93fa50145207",
+                "reference": "ce20367d07b2592202e9c266b16a93fa50145207",
                 "shasum": ""
             },
             "require": {
@@ -10518,7 +10510,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.4.17"
+                "source": "https://github.com/symfony/validator/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -10534,20 +10526,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T12:50:19+00:00"
+            "time": "2025-01-27T16:05:44+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.15",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "38254d5a5ac2e61f2b52f9caf54e7aa3c9d36b80"
+                "reference": "4ad10cf8b020e77ba665305bb7804389884b4837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/38254d5a5ac2e61f2b52f9caf54e7aa3c9d36b80",
-                "reference": "38254d5a5ac2e61f2b52f9caf54e7aa3c9d36b80",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4ad10cf8b020e77ba665305bb7804389884b4837",
+                "reference": "4ad10cf8b020e77ba665305bb7804389884b4837",
                 "shasum": ""
             },
             "require": {
@@ -10603,7 +10595,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.15"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -10619,7 +10611,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T15:28:48+00:00"
+            "time": "2025-01-17T11:26:11+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -10700,16 +10692,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.13",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e99b4e94d124b29ee4cf3140e1b537d2dad8cec9"
+                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e99b4e94d124b29ee4cf3140e1b537d2dad8cec9",
-                "reference": "e99b4e94d124b29ee4cf3140e1b537d2dad8cec9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
+                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
                 "shasum": ""
             },
             "require": {
@@ -10752,7 +10744,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -10768,7 +10760,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2025-01-07T09:44:41+00:00"
         },
         {
             "name": "twig/twig",
@@ -11591,16 +11583,16 @@
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915"
+                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
+                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
                 "shasum": ""
             },
             "require": {
@@ -11644,7 +11636,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.5.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.6.0"
             },
             "funding": [
                 {
@@ -11660,20 +11652,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T16:11:06+00:00"
+            "time": "2025-02-05T10:05:34+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.8.4",
+            "version": "2.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "112e37d1dca22b3fdb81cf3524ab4994f47fdb8c"
+                "reference": "ae208dc1e182bd45d99fcecb956501da212454a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/112e37d1dca22b3fdb81cf3524ab4994f47fdb8c",
-                "reference": "112e37d1dca22b3fdb81cf3524ab4994f47fdb8c",
+                "url": "https://api.github.com/repos/composer/composer/zipball/ae208dc1e182bd45d99fcecb956501da212454a1",
+                "reference": "ae208dc1e182bd45d99fcecb956501da212454a1",
                 "shasum": ""
             },
             "require": {
@@ -11758,7 +11750,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.8.4"
+                "source": "https://github.com/composer/composer/tree/2.8.5"
             },
             "funding": [
                 {
@@ -11774,7 +11766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-11T10:57:47+00:00"
+            "time": "2025-01-21T14:23:40+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -12323,16 +12315,16 @@
         },
         {
             "name": "drupal/coder",
-            "version": "8.3.27",
+            "version": "8.3.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pfrenssen/coder.git",
-                "reference": "04a4563b82c419e43cc58393a78b21c44fcc29e2"
+                "reference": "d18eeb133f7da766f0341734aa983d05f2b317fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/04a4563b82c419e43cc58393a78b21c44fcc29e2",
-                "reference": "04a4563b82c419e43cc58393a78b21c44fcc29e2",
+                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/d18eeb133f7da766f0341734aa983d05f2b317fd",
+                "reference": "d18eeb133f7da766f0341734aa983d05f2b317fd",
                 "shasum": ""
             },
             "require": {
@@ -12370,7 +12362,7 @@
                 "issues": "https://www.drupal.org/project/issues/coder",
                 "source": "https://www.drupal.org/project/coder"
             },
-            "time": "2025-01-06T09:46:24+00:00"
+            "time": "2025-01-18T17:05:53+00:00"
         },
         {
             "name": "drupal/core-dev",
@@ -12877,16 +12869,16 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "bbb92dee546da3988da851122cb2925f72c149f3"
+                "reference": "2a30d8d3ca170d86b1829e3cb8037ad87b82f20d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/bbb92dee546da3988da851122cb2925f72c149f3",
-                "reference": "bbb92dee546da3988da851122cb2925f72c149f3",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/2a30d8d3ca170d86b1829e3cb8037ad87b82f20d",
+                "reference": "2a30d8d3ca170d86b1829e3cb8037ad87b82f20d",
                 "shasum": ""
             },
             "require": {
@@ -12961,7 +12953,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.3.2"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.3.3"
             },
             "funding": [
                 {
@@ -12977,7 +12969,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-19T15:26:05+00:00"
+            "time": "2025-01-23T15:21:21+00:00"
         },
         {
             "name": "micheh/phpcs-gitlab",
@@ -13085,16 +13077,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -13133,7 +13125,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -13141,7 +13133,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nuvoleweb/drupal-behat",
@@ -13295,16 +13287,16 @@
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "351a30baa79699de3de3a814c8ccc7b52ccdfb1d"
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/351a30baa79699de3de3a814c8ccc7b52ccdfb1d",
-                "reference": "351a30baa79699de3de3a814c8ccc7b52ccdfb1d",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/8b925df3047628968bc5be722468db1b98b82d51",
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51",
                 "shasum": ""
             },
             "require": {
@@ -13361,7 +13353,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-08T23:50:34+00:00"
+            "time": "2025-02-03T21:49:11+00:00"
         },
         {
             "name": "open-telemetry/context",
@@ -13551,16 +13543,16 @@
         },
         {
             "name": "open-telemetry/sdk",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "9a1c3b866239dbff291e5cc555bb7793eab08127"
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/9a1c3b866239dbff291e5cc555bb7793eab08127",
-                "reference": "9a1c3b866239dbff291e5cc555bb7793eab08127",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/37eec0fe47ddd627911f318f29b6cd48196be0c0",
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0",
                 "shasum": ""
             },
             "require": {
@@ -13637,24 +13629,24 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-08T23:50:34+00:00"
+            "time": "2025-01-29T21:40:28+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
-            "version": "1.27.1",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6"
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/1dba705fea74bc0718d04be26090e3697e56f4e6",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.0"
             },
             "type": "library",
             "extra": {
@@ -13694,7 +13686,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2024-08-28T09:20:31+00:00"
+            "time": "2025-02-06T00:21:48+00:00"
         },
         {
             "name": "palantirnet/drupal-rector",
@@ -14543,16 +14535,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.15",
+            "version": "1.12.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1"
+                "reference": "fef9f07814a573399229304bb0046affdf558812"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c91d4e8bc056f46cf653656e6f71004b254574d1",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fef9f07814a573399229304bb0046affdf558812",
+                "reference": "fef9f07814a573399229304bb0046affdf558812",
                 "shasum": ""
             },
             "require": {
@@ -14597,7 +14589,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T16:40:22+00:00"
+            "time": "2025-02-13T12:44:44+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -16908,16 +16900,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.2",
+            "version": "3.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
                 "shasum": ""
             },
             "require": {
@@ -16982,9 +16974,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-12-11T16:04:26+00:00"
+            "time": "2025-01-23T17:04:15+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -17196,16 +17192,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v6.4.16",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "4304e6ad5c894a9c72831ad459f627bfd35d766d"
+                "reference": "fd07959d3e8992795029bdab3605c2e8e895034e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/4304e6ad5c894a9c72831ad459f627bfd35d766d",
-                "reference": "4304e6ad5c894a9c72831ad459f627bfd35d766d",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/fd07959d3e8992795029bdab3605c2e8e895034e",
+                "reference": "fd07959d3e8992795029bdab3605c2e8e895034e",
                 "shasum": ""
             },
             "require": {
@@ -17243,7 +17239,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.16"
+                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -17259,20 +17255,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T15:06:22+00:00"
+            "time": "2025-01-09T15:35:00+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.17",
+            "version": "v6.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "88898d842eb29d7e1a903724c94e90a6ca9c0509"
+                "reference": "394b440934056b8d9d6ba250001458e9d7998b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/88898d842eb29d7e1a903724c94e90a6ca9c0509",
-                "reference": "88898d842eb29d7e1a903724c94e90a6ca9c0509",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/394b440934056b8d9d6ba250001458e9d7998b7f",
+                "reference": "394b440934056b8d9d6ba250001458e9d7998b7f",
                 "shasum": ""
             },
             "require": {
@@ -17336,7 +17332,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.17"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.18"
             },
             "funding": [
                 {
@@ -17352,7 +17348,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-18T12:18:31+00:00"
+            "time": "2025-01-28T15:49:13+00:00"
         },
         {
             "name": "symfony/http-client-contracts",

--- a/upstream-configuration/patches.webspark.json
+++ b/upstream-configuration/patches.webspark.json
@@ -3,7 +3,8 @@
         "#2951547: Fix issue with layout overflow": "https://www.drupal.org/files/issues/2022-07-13/f245f21ea664f22c81d8d28c6f0f4a42fb9a5890.patch",
         "#3109650: Refactor Xss::attributes() to allow filtering of style attribute values": "https://www.drupal.org/files/issues/2024-05-16/core-10.2.3-xss-refactor_filter_attributes-3109650-74.patch",
         "#3415961: Fix issue with focus after inserting media via the modal dialog": "https://www.drupal.org/files/issues/2024-02-15/3415961.patch",
-        "#3386605: Add CKEditor 5 support for WebP images": "https://www.drupal.org/files/issues/2024-08-14/3386605-9-add-ckeditor5-support-for-webp.patch"
+        "#3386605: Add CKEditor 5 support for WebP images": "https://www.drupal.org/files/issues/2024-08-14/3386605-9-add-ckeditor5-support-for-webp.patch",
+        "#3135592: Cannot implement a custom user cancellation method": "web/modules/asu_modules/asu_secure_superadmin/patch/user-module-3135592-2241mr-c39.patch"
     },
     "drupal/config_readonly": {
         "#3085001: Config blacklist to only block some configuration while in read only mode": "https://www.drupal.org/files/issues/2019-10-31/config_readonly-3085001-2.patch"

--- a/web/modules/asu_modules/asu_secure_superadmin/LICENSE
+++ b/web/modules/asu_modules/asu_secure_superadmin/LICENSE
@@ -1,0 +1,32 @@
+Copyright (c) 2019-2023 Arizona Board of Regents. All rights reserved.
+
+Arizona State University's registered trademarks, service marks, word
+marks, and logos, including "Arizona State University,"  "ASU," seal,
+and athletic mascot Sparky, may not be used or reproduced without
+permission.  Any individual, organization, or company wishing to use
+Arizona State University's logos and trademarks must obtain the right to
+do so in writing from the university.
+
+Any other file of this project is available under the MIT license as follow:
+
+MIT License
+
+Copyright (c) 2019-2023 Arizona Board of Regents. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/web/modules/asu_modules/asu_secure_superadmin/README.md
+++ b/web/modules/asu_modules/asu_secure_superadmin/README.md
@@ -23,7 +23,7 @@ If you are using a Composer workflow and have the `cweagans/composer-patches` pa
     "extra": {
         "patches": {
             "drupal/core": {
-                "Add user1 account migration": "web/modules/asu_modules/asu_secure_superadmin/patch/drupal-10.3.11-user1-migration.patch"
+                "Add user1 account migration": "web/modules/asu_modules/asu_secure_superadmin/patch/user-module-3135592-2241mr-c39.patch"
             }
         }
     }
@@ -36,4 +36,4 @@ After successfully applying the core patch, install this module as you would nor
 See: https://www.drupal.org/node/895232 for further information.
 
 ## Configuration
-This module has a configuration page located at `/admin/config/system/asu-secure-superadmin/settings`. This page houses a very simple form with a single button that can be clicked to trigger the process of securing the superadmin user account.
+No special configuration is needed for this module. Its functionality is automatically enabled and run on module installation.

--- a/web/modules/asu_modules/asu_secure_superadmin/README.md
+++ b/web/modules/asu_modules/asu_secure_superadmin/README.md
@@ -36,4 +36,4 @@ After successfully applying the core patch, install this module as you would nor
 See: https://www.drupal.org/node/895232 for further information.
 
 ## Configuration
-No special configuration is needed for this module. Its functionality is automatically enabled and run on module installation.
+This module has a configuration page located at `/admin/config/system/asu-secure-superadmin/settings`. This page houses a very simple form with a single button that can be clicked to trigger the process of securing the superadmin user account.

--- a/web/modules/asu_modules/asu_secure_superadmin/README.md
+++ b/web/modules/asu_modules/asu_secure_superadmin/README.md
@@ -1,0 +1,39 @@
+# ASU Secure Superadmin
+
+## Introduction
+The `asu_secure_superadmin` module is intended to provide Enterprise Technology with a tool to secure the user1 account in Drupal sites on the Acquia platform.
+This module does the following:
+
+- Copies the user1 account to a new account
+- Changes the user1 account to a new username (etsuper) and randomized password
+- Disables the user1 account
+- Creates a new user account with the username and content of the original user1 account
+- Migrates the content of the original user1 account to the new account
+
+## Requirements
+In order for this module to work properly, it requires a patch to be applied to the Drupal core's user module prior to installation.
+The patch is targeted for `Drupal 10.3.11` and can be found in the `patch` directory of this module. If your version
+of Drupal is different, you may need to [re-roll](https://www.drupal.org/docs/develop/git/using-git-to-contribute-to-drupal/rerolling-patches) the patch for your version of Drupal.
+This module is intended to be used only on ASU Drupal sites hosted on the Acquia platform.
+
+## Installation
+If you are using a Composer workflow and have the `cweagans/composer-patches` package installed, add the patch to your composer file like so:
+```json
+{
+    "extra": {
+        "patches": {
+            "drupal/core": {
+                "Add user1 account migration": "web/modules/asu_modules/asu_secure_superadmin/patch/drupal-10.3.11-user1-migration.patch"
+            }
+        }
+    }
+}
+```
+The snippet above assumes that your Drupal root is in a directory called `web`. If your Drupal root is in a different directory, you will need to adjust the path to the patch file accordingly.
+If you are not using Composer or `cweagans/composer-patches`, you will need to add the patch manually to your Drupal codebase. Instructions for how to do this can be found at https://www.drupal.org/patch/apply.
+
+After successfully applying the core patch, install this module as you would normally install a contributed Drupal module.
+See: https://www.drupal.org/node/895232 for further information.
+
+## Configuration
+No special configuration is needed for this module. Its functionality is automatically enabled and run on module installation.

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.info.yml
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.info.yml
@@ -1,0 +1,5 @@
+name: 'ASU Secure Superadmin'
+type: module
+description: 'This module is meant to secure the user 1 super admin account.'
+package: ASU
+core_version_requirement: ^10.3.11

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.info.yml
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'This module is meant to secure the user 1 super admin account.'
 package: ASU
 core_version_requirement: ^10.3.11
+dependencies:
+  - drupal:cas

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.install
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the asu_secure_superadmin module.
  */
 
+use Drupal\user\Entity\User;
+
 /**
  * Implements hook_requirements().
  *
@@ -26,13 +28,9 @@ function asu_secure_superadmin_requirements($phase) :array {
 }
 
 function asu_secure_superadmin_install() {
-  try {
-    \Drupal::service('asu_secure_superadmin.change_super_admin_service')->changeSuperAdmin();
+  $user = User::load(1);
+  $already_secure = ($user && $user->getAccountName() === 'etsuper');
+  if (!$already_secure) {
+    \Drupal::messenger()->addMessage(\Drupal\Core\Render\Markup::create('The ASU Secure Superadmin module has been installed. Please visit <a href="/admin/config/system/asu-secure-superadmin/settings">the settings page</a> to secure the Superadmin account.'));
   }
-  catch (\Exception $e) {
-    \Drupal::logger('asu_secure_superadmin')->error($e->getMessage());
-    \Drupal::messenger()->addError($e->getMessage());
-    return;
-  }
-  \Drupal::messenger()->addMessage('The super admin has been changed.');
 }

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.install
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.install
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the asu_secure_superadmin module.
+ */
+
+/**
+ * Implements hook_requirements().
+ *
+ * @throws \JsonException
+ */
+function asu_secure_superadmin_requirements($phase) :array {
+  $requirements = [];
+  $patchName = 'user-module-3135592-2241mr-c39.patch';
+  $filePath = DRUPAL_ROOT . '/core/modules/user/src/Event/AccountCancelEvent.php';
+
+  if (($phase === 'install') && !file_exists($filePath)) {
+    $requirements['asu_secure_superadmin_patch_test'] = [
+      'description' => t('The ASU Secure Superadmin module requires the @patch_name. Your site does not have this patch installed.', ['@patch_name' => $patchName]),
+      'severity' => REQUIREMENT_ERROR,
+    ];
+  }
+
+  return $requirements;
+}
+
+function asu_secure_superadmin_install() {
+  try {
+    \Drupal::service('asu_secure_superadmin.change_super_admin_service')->changeSuperAdmin();
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('asu_secure_superadmin')->error($e->getMessage());
+    \Drupal::messenger()->addError($e->getMessage());
+    return;
+  }
+  \Drupal::messenger()->addMessage('The super admin has been changed.');
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.links.menu.yml
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.links.menu.yml
@@ -1,0 +1,4 @@
+asu_secure_superadmin.settings:
+  title: ASU Secure SuperAdmin Settings
+  parent: system.admin_config_system
+  route_name: asu_secure_superadmin.settings

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.module
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for asu_secure_superadmin module.
+ */

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.routing.yml
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.routing.yml
@@ -1,0 +1,7 @@
+asu_secure_superadmin.settings:
+  path: '/admin/config/system/asu-secure-superadmin/settings'
+  defaults:
+    _title: 'ASU Secure SuperAdmin Settings'
+    _form: 'Drupal\asu_secure_superadmin\Form\SettingsForm'
+  requirements:
+    _permission: 'administer site configuration'

--- a/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.services.yml
+++ b/web/modules/asu_modules/asu_secure_superadmin/asu_secure_superadmin.services.yml
@@ -1,0 +1,19 @@
+services:
+  asu_secure_superadmin.change_super_admin_service:
+    class: Drupal\asu_secure_superadmin\Services\ChangeSuperAdminService
+    arguments: [ '@entity_type.manager', '@event_dispatcher', '@cas.user_manager', '@password_generator']
+
+  asu_secure_superadmin.account_cancel.subscriber:
+    class: Drupal\asu_secure_superadmin\EventSubscriber\CustomUserCancelSubscriber
+    tags:
+      - { name: event_subscriber }
+
+  asu_secure_superadmin.entity_cancel.subscriber:
+    class: Drupal\asu_secure_superadmin\EventSubscriber\EntityAccountCancelSubscriber
+    arguments: ['@entity_type.manager','@module_handler' , '@asu_secure_superadmin.entity_mass_update']
+    tags:
+      - { name: event_subscriber }
+
+  asu_secure_superadmin.entity_mass_update:
+    class: Drupal\asu_secure_superadmin\Services\EntityMassUpdateService
+    arguments: ['@entity_type.manager', '@extension.list.module', '@messenger', '@renderer', '@string_translation']

--- a/web/modules/asu_modules/asu_secure_superadmin/composer.json
+++ b/web/modules/asu_modules/asu_secure_superadmin/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "asuwebplatforms/asu_secure_superadmin",
+    "description": "Secure Superadmin account on ASU Drupal sites",
+    "type": "drupal-module",
+    "license": "MIT"
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/patch/user-module-3135592-2241mr-c39.patch
+++ b/web/modules/asu_modules/asu_secure_superadmin/patch/user-module-3135592-2241mr-c39.patch
@@ -1,0 +1,1555 @@
+diff --git a/core/modules/comment/comment.module b/core/modules/comment/comment.module
+index 0928695ed15..7dfc19e6541 100644
+--- a/core/modules/comment/comment.module
++++ b/core/modules/comment/comment.module
+@@ -26,7 +26,6 @@
+ use Drupal\field\FieldStorageConfigInterface;
+ use Drupal\node\NodeInterface;
+ use Drupal\user\RoleInterface;
+-use Drupal\user\UserInterface;
+
+ /**
+  * The time cutoff for comments marked as read for entity types other node.
+@@ -447,38 +446,6 @@ function comment_node_search_result(EntityInterface $node) {
+   }
+ }
+
+-/**
+- * Implements hook_user_cancel().
+- */
+-function comment_user_cancel($edit, UserInterface $account, $method) {
+-  switch ($method) {
+-    case 'user_cancel_block_unpublish':
+-      $comments = \Drupal::entityTypeManager()->getStorage('comment')->loadByProperties(['uid' => $account->id()]);
+-      foreach ($comments as $comment) {
+-        $comment->setUnpublished();
+-        $comment->save();
+-      }
+-      break;
+-
+-    case 'user_cancel_reassign':
+-      /** @var \Drupal\comment\CommentInterface[] $comments */
+-      $comments = \Drupal::entityTypeManager()->getStorage('comment')->loadByProperties(['uid' => $account->id()]);
+-      foreach ($comments as $comment) {
+-        $langcodes = array_keys($comment->getTranslationLanguages());
+-        // For efficiency manually save the original comment before applying any
+-        // changes.
+-        $comment->original = clone $comment;
+-        foreach ($langcodes as $langcode) {
+-          $comment_translated = $comment->getTranslation($langcode);
+-          $comment_translated->setOwnerId(0);
+-          $comment_translated->setAuthorName(\Drupal::config('user.settings')->get('anonymous'));
+-        }
+-        $comment->save();
+-      }
+-      break;
+-  }
+-}
+-
+ /**
+  * Implements hook_ENTITY_TYPE_predelete() for user entities.
+  */
+diff --git a/core/modules/comment/comment.services.yml b/core/modules/comment/comment.services.yml
+index 9bbf020ec5a..687b5122c2d 100644
+--- a/core/modules/comment/comment.services.yml
++++ b/core/modules/comment/comment.services.yml
+@@ -27,3 +27,9 @@ services:
+     class: Drupal\comment\CommentLinkBuilder
+     arguments: ['@current_user', '@comment.manager', '@module_handler', '@string_translation', '@entity_type.manager']
+   Drupal\comment\CommentLinkBuilderInterface: '@comment.link_builder'
++
++  comment.account_cancel.subscriber:
++    class: Drupal\comment\EventSubscriber\CommentAccountCancelSubscriber
++    arguments: ['@entity_type.manager', '@config.factory']
++    tags:
++      - { name: event_subscriber }
+diff --git a/core/modules/comment/src/EventSubscriber/CommentAccountCancelSubscriber.php b/core/modules/comment/src/EventSubscriber/CommentAccountCancelSubscriber.php
+new file mode 100644
+index 00000000000..98fc8ded3f4
+--- /dev/null
++++ b/core/modules/comment/src/EventSubscriber/CommentAccountCancelSubscriber.php
+@@ -0,0 +1,86 @@
++<?php
++
++namespace Drupal\comment\EventSubscriber;
++
++use Drupal\Core\Config\ConfigFactoryInterface;
++use Drupal\Core\Entity\EntityTypeManagerInterface;
++use Drupal\user\Event\AccountCancelEvent;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Performs comment module operations when a user account is cancelled.
++ */
++class CommentAccountCancelSubscriber implements EventSubscriberInterface {
++
++  /**
++   * The entity type manager service.
++   *
++   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
++   */
++  protected EntityTypeManagerInterface $entityTypeManager;
++
++  /**
++   * The config factory service.
++   *
++   * @var \Drupal\Core\Config\ConfigFactoryInterface
++   */
++  protected ConfigFactoryInterface $configFactory;
++
++  /**
++   * Constructs a new event subscriber instance.
++   *
++   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
++   *   The entity type manager service.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory service.
++   */
++  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
++    $this->entityTypeManager = $entity_type_manager;
++    $this->configFactory = $config_factory;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    return [
++      // Act before AccountCancelSubscriber::onUserAccountCancel()
++      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
++      AccountCancelEvent::class => ['onUserAccountCancel', 20],
++    ];
++  }
++
++  /**
++   * Acts on user account cancel event.
++   *
++   * @param \Drupal\user\Event\AccountCancelEvent $event
++   *   The user cancel event.
++   *
++   * @todo Convert to a batch process in #3007581.
++   * @see https://www.drupal.org/project/drupal/issues/3007581
++   */
++  public function onUserAccountCancel(AccountCancelEvent $event): void {
++    $method = $event->getMethod();
++    if (!in_array($method, [
++      'user_cancel_block_unpublish',
++      'user_cancel_reassign',
++    ], TRUE)) {
++      return;
++    }
++
++    /** @var \Drupal\comment\CommentInterface[] $comments */
++    $comments = $this->entityTypeManager->getStorage('comment')->loadByProperties([
++      'uid' => $event->getAccount()->id(),
++    ]);
++    $anonymous_name = $this->configFactory->get('user.settings')->get('anonymous');
++    foreach ($comments as $comment) {
++      if ($method === 'user_cancel_block_unpublish') {
++        $comment->setUnpublished()->save();
++      }
++      else {
++        $comment->setOwnerId(0)->setAuthorName($anonymous_name)->save();
++      }
++    }
++  }
++
++}
+diff --git a/core/modules/history/history.module b/core/modules/history/history.module
+index f30ec39d880..259a3b132ee 100644
+--- a/core/modules/history/history.module
++++ b/core/modules/history/history.module
+@@ -11,7 +11,6 @@
+ use Drupal\Core\Entity\EntityInterface;
+ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+ use Drupal\Core\Routing\RouteMatchInterface;
+-use Drupal\user\UserInterface;
+
+ /**
+  * Entities changed before this time are always shown as read.
+@@ -162,19 +161,6 @@ function history_node_delete(EntityInterface $node) {
+     ->execute();
+ }
+
+-/**
+- * Implements hook_user_cancel().
+- */
+-function history_user_cancel($edit, UserInterface $account, $method) {
+-  switch ($method) {
+-    case 'user_cancel_reassign':
+-      \Drupal::database()->delete('history')
+-        ->condition('uid', $account->id())
+-        ->execute();
+-      break;
+-  }
+-}
+-
+ /**
+  * Implements hook_ENTITY_TYPE_delete() for user entities.
+  */
+diff --git a/core/modules/history/history.services.yml b/core/modules/history/history.services.yml
+new file mode 100644
+index 00000000000..b6b623d3999
+--- /dev/null
++++ b/core/modules/history/history.services.yml
+@@ -0,0 +1,7 @@
++services:
++
++  history.account_cancel.subscriber:
++    class: Drupal\history\EventSubscriber\HistoryAccountCancelSubscriber
++    arguments: ['@database']
++    tags:
++      - { name: event_subscriber }
+diff --git a/core/modules/history/src/EventSubscriber/HistoryAccountCancelSubscriber.php b/core/modules/history/src/EventSubscriber/HistoryAccountCancelSubscriber.php
+new file mode 100644
+index 00000000000..c7ab674565f
+--- /dev/null
++++ b/core/modules/history/src/EventSubscriber/HistoryAccountCancelSubscriber.php
+@@ -0,0 +1,56 @@
++<?php
++
++namespace Drupal\history\EventSubscriber;
++
++use Drupal\Core\Database\Connection;
++use Drupal\user\Event\AccountCancelEvent;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Performs history module operations when a user account is cancelled.
++ */
++class HistoryAccountCancelSubscriber implements EventSubscriberInterface {
++
++  /**
++   * The database connection.
++   *
++   * @var \Drupal\Core\Database\Connection
++   */
++  protected Connection $database;
++
++  /**
++   * Constructs a new event subscriber instance.
++   *
++   * @param \Drupal\Core\Database\Connection $database
++   *   The database connection.
++   */
++  public function __construct(Connection $database) {
++    $this->database = $database;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    return [
++      // Act before AccountCancelSubscriber::onUserAccountCancel()
++      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
++      AccountCancelEvent::class => ['onUserAccountCancel', 20],
++    ];
++  }
++
++  /**
++   * Acts on user account cancel event.
++   *
++   * @param \Drupal\user\Event\AccountCancelEvent $event
++   *   The user cancel event.
++   */
++  public function onUserAccountCancel(AccountCancelEvent $event): void {
++    if ($event->getMethod() === 'user_cancel_reassign') {
++      $this->database->delete('history')
++        ->condition('uid', $event->getAccount()->id())
++        ->execute();
++    }
++  }
++
++}
+diff --git a/core/modules/jsonapi/jsonapi.services.yml b/core/modules/jsonapi/jsonapi.services.yml
+index 0f9b2435d5c..f7f36624406 100644
+--- a/core/modules/jsonapi/jsonapi.services.yml
++++ b/core/modules/jsonapi/jsonapi.services.yml
+@@ -196,6 +196,7 @@ services:
+       - '@jsonapi.serializer'
+       - '@datetime.time'
+       - '@current_user'
++      - '@user.account_cancellation'
+   Drupal\jsonapi\Controller\EntityResource: '@jsonapi.entity_resource'
+   jsonapi.file_upload:
+     class: Drupal\jsonapi\Controller\FileUpload
+diff --git a/core/modules/jsonapi/src/Controller/EntityResource.php b/core/modules/jsonapi/src/Controller/EntityResource.php
+index 7ddf02b8469..c22d55b053a 100644
+--- a/core/modules/jsonapi/src/Controller/EntityResource.php
++++ b/core/modules/jsonapi/src/Controller/EntityResource.php
+@@ -52,6 +52,7 @@
+ use Drupal\jsonapi\ResourceType\ResourceTypeField;
+ use Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface;
+ use Drupal\jsonapi\Revisions\ResourceVersionRouteEnhancer;
++use Drupal\user\AccountCancellationInterface;
+ use Symfony\Component\HttpFoundation\Request;
+ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+ use Drupal\Core\Http\Exception\CacheableBadRequestHttpException;
+@@ -151,6 +152,13 @@ class EntityResource {
+    */
+   protected $user;
+
++  /**
++   * The account cancellation service.
++   *
++   * @var \Drupal\user\AccountCancellationInterface
++   */
++  protected AccountCancellationInterface $accountCancellation;
++
+   /**
+    * Instantiates an EntityResource object.
+    *
+@@ -176,8 +184,10 @@ class EntityResource {
+    *   The time service.
+    * @param \Drupal\Core\Session\AccountInterface $user
+    *   The current user account.
++   * @param \Drupal\user\AccountCancellationInterface $account_cancellation
++   *   The account cancellation service.
+    */
+-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $field_manager, ResourceTypeRepositoryInterface $resource_type_repository, RendererInterface $renderer, EntityRepositoryInterface $entity_repository, IncludeResolver $include_resolver, EntityAccessChecker $entity_access_checker, FieldResolver $field_resolver, SerializerInterface $serializer, TimeInterface $time, AccountInterface $user) {
++  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $field_manager, ResourceTypeRepositoryInterface $resource_type_repository, RendererInterface $renderer, EntityRepositoryInterface $entity_repository, IncludeResolver $include_resolver, EntityAccessChecker $entity_access_checker, FieldResolver $field_resolver, SerializerInterface $serializer, TimeInterface $time, AccountInterface $user, AccountCancellationInterface $account_cancellation) {
+     $this->entityTypeManager = $entity_type_manager;
+     $this->fieldManager = $field_manager;
+     $this->resourceTypeRepository = $resource_type_repository;
+@@ -189,6 +199,7 @@ public function __construct(EntityTypeManagerInterface $entity_type_manager, Ent
+     $this->serializer = $serializer;
+     $this->time = $time;
+     $this->user = $user;
++    $this->accountCancellation = $account_cancellation;
+   }
+
+   /**
+@@ -375,9 +386,9 @@ public function deleteIndividual(EntityInterface $entity) {
+
+       // Allow other modules to act.
+
+-      user_cancel([], $entity->id(), $cancel_method);
+-      // Since user_cancel() is not invoked via Form API, batch processing
+-      // needs to be invoked manually.
++      $this->accountCancellation->cancel($entity, $cancel_method);
++      // Since $this->accountCancellation->cancel() is not invoked via Form API,
++      // batch processing needs to be invoked manually.
+       $batch =& batch_get();
+       // Mark this batch as non-progressive to bypass the progress bar and
+       // redirect.
+diff --git a/core/modules/node/node.module b/core/modules/node/node.module
+index 43c65f590bc..907ee7817a7 100644
+--- a/core/modules/node/node.module
++++ b/core/modules/node/node.module
+@@ -661,33 +661,6 @@ function node_ranking() {
+   return $ranking;
+ }
+
+-/**
+- * Implements hook_user_cancel().
+- */
+-function node_user_cancel($edit, UserInterface $account, $method) {
+-  switch ($method) {
+-    case 'user_cancel_block_unpublish':
+-      // Unpublish nodes (current revisions).
+-      $nids = \Drupal::entityQuery('node')
+-        ->accessCheck(FALSE)
+-        ->condition('uid', $account->id())
+-        ->execute();
+-      \Drupal::moduleHandler()->loadInclude('node', 'inc', 'node.admin');
+-      node_mass_update($nids, ['status' => 0], NULL, TRUE);
+-      break;
+-
+-    case 'user_cancel_reassign':
+-      // Anonymize all of the nodes for this old account.
+-      \Drupal::moduleHandler()->loadInclude('node', 'inc', 'node.admin');
+-      $vids = \Drupal::entityTypeManager()->getStorage('node')->userRevisionIds($account);
+-      node_mass_update($vids, [
+-        'uid' => 0,
+-        'revision_uid' => 0,
+-      ], NULL, TRUE, TRUE);
+-      break;
+-  }
+-}
+-
+ /**
+  * Implements hook_ENTITY_TYPE_predelete() for user entities.
+  */
+diff --git a/core/modules/node/node.services.yml b/core/modules/node/node.services.yml
+index e5daad35429..7a2867c926b 100644
+--- a/core/modules/node/node.services.yml
++++ b/core/modules/node/node.services.yml
+@@ -40,3 +40,8 @@ services:
+     arguments: ['@current_route_match']
+     tags:
+       - { name: 'context_provider' }
++  node.account_cancel.subscriber:
++    class: Drupal\node\EventSubscriber\NodeAccountCancelSubscriber
++    arguments: ['@entity_type.manager', '@module_handler']
++    tags:
++      - { name: event_subscriber }
+diff --git a/core/modules/node/src/EventSubscriber/NodeAccountCancelSubscriber.php b/core/modules/node/src/EventSubscriber/NodeAccountCancelSubscriber.php
+new file mode 100644
+index 00000000000..cb5b2ee3cf9
+--- /dev/null
++++ b/core/modules/node/src/EventSubscriber/NodeAccountCancelSubscriber.php
+@@ -0,0 +1,81 @@
++<?php
++
++namespace Drupal\node\EventSubscriber;
++
++use Drupal\Core\Entity\EntityTypeManagerInterface;
++use Drupal\Core\Extension\ModuleHandlerInterface;
++use Drupal\user\Event\AccountCancelEvent;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Performs node module operations when a user account is cancelled.
++ */
++class NodeAccountCancelSubscriber implements EventSubscriberInterface {
++
++  /**
++   * The entity type manager service.
++   *
++   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
++   */
++  protected EntityTypeManagerInterface $entityTypeManager;
++
++  /**
++   * The module handler service.
++   *
++   * @var \Drupal\Core\Extension\ModuleHandlerInterface
++   */
++  protected ModuleHandlerInterface $moduleHandler;
++
++  /**
++   * Constructs a new event subscriber instance.
++   *
++   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
++   *   The entity type manager service.
++   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
++   *   The module handler service.
++   */
++  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler) {
++    $this->entityTypeManager = $entity_type_manager;
++    $this->moduleHandler = $module_handler;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    return [
++      // Act before AccountCancelSubscriber::onUserAccountCancel()
++      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
++      AccountCancelEvent::class => ['onUserAccountCancel', 20],
++    ];
++  }
++
++  /**
++   * Acts on user account cancel event.
++   *
++   * @param \Drupal\user\Event\AccountCancelEvent $event
++   *   The user cancel event.
++   */
++  public function onUserAccountCancel(AccountCancelEvent $event): void {
++    $method = $event->getMethod();
++    if ($method === 'user_cancel_block_unpublish') {
++      // Unpublish nodes (current revisions).
++      $nids = $this->entityTypeManager->getStorage('node')->getQuery()
++        ->accessCheck(FALSE)
++        ->condition('uid', $event->getAccount()->id())
++        ->execute();
++      $this->moduleHandler->loadInclude('node', 'inc', 'node.admin');
++      node_mass_update($nids, ['status' => 0], NULL, TRUE);
++    }
++    elseif ($method === 'user_cancel_reassign') {
++      // Anonymize all the nodes for this old account.
++      $vids = $this->entityTypeManager->getStorage('node')->userRevisionIds($event->getAccount());
++      $this->moduleHandler->loadInclude('node', 'inc', 'node.admin');
++      node_mass_update($vids, [
++        'uid' => 0,
++        'revision_uid' => 0,
++      ], NULL, TRUE, TRUE);
++    }
++  }
++
++}
+diff --git a/core/modules/user/src/AccountCancellation.php b/core/modules/user/src/AccountCancellation.php
+new file mode 100644
+index 00000000000..e4d0c535697
+--- /dev/null
++++ b/core/modules/user/src/AccountCancellation.php
+@@ -0,0 +1,102 @@
++<?php
++
++namespace Drupal\user;
++
++use Drupal\Core\Batch\BatchBuilder;
++use Drupal\Core\Extension\ModuleHandlerInterface;
++use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Drupal\user\Event\AccountCancelEvent;
++use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
++
++/**
++ * Provides user account cancellation functionality.
++ *
++ * Third-party, having something to say on user cancellation, should subscribe
++ * to \Drupal\user\Event\AccountCancelEvent event. The 'user' module provides
++ * its own subscriber (\Drupal\user\EventSubscriber\AccountCancelSubscriber)
++ * that actually performs the cancellation. A subscriber aiming to implement its
++ * own user account cancellation logic and avoid default core behavior should
++ * set a higher priority and bypass downstream subscribers by stopping the event
++ * propagation.
++ *
++ * @see \Drupal\user\Event\AccountCancelEvent
++ * @see \Drupal\user\EventSubscriber\AccountCancelSubscriber
++ */
++class AccountCancellation implements AccountCancellationInterface {
++
++  use StringTranslationTrait;
++
++  /**
++   * The module handler service.
++   *
++   * @var \Drupal\Core\Extension\ModuleHandlerInterface
++   */
++  protected ModuleHandlerInterface $moduleHandler;
++
++  /**
++   * The event dispatcher service.
++   *
++   * @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
++   */
++  protected EventDispatcherInterface $eventDispatcher;
++
++  /**
++   * Constructs a new service instance.
++   *
++   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
++   *   The module handler service.
++   * @param \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $event_dispatcher
++   *   The event dispatcher service.
++   */
++  public function __construct(ModuleHandlerInterface $module_handler, EventDispatcherInterface $event_dispatcher) {
++    $this->moduleHandler = $module_handler;
++    $this->eventDispatcher = $event_dispatcher;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function cancel(UserInterface $account, string $method, array $context = []): void {
++    // Initialize batch (to set title).
++    $batch_builder = (new BatchBuilder())
++      ->setTitle($this->t('Cancelling account'));
++    batch_set($batch_builder->toArray());
++
++    // When the 'user_cancel_delete' method is used, the user entity is deleted,
++    // which invokes hook_ENTITY_TYPE_predelete() and hook_ENTITY_TYPE_delete().
++    // Modules should use those hooks to respond to the account deletion.
++    if ($method !== 'user_cancel_delete') {
++      // Allow modules to add further sets to this batch.
++      $description = 'The hook is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. In order to act on user account cancellation provide an event subscriber that listens to the \Drupal\user\Event\AccountCancelEvent event. The event subscriber can be defined with a priority higher than the core subscribers in order to cancel them by using AccountCancelEvent::stopPropagation(). See https://www.drupal.org/node/3279455';
++      $this->moduleHandler->invokeAllDeprecated($description, 'user_cancel', [$context, $account, $method]);
++    }
++
++    // Allow third-party to add further sets to this batch.
++    $account_cancel_event = new AccountCancelEvent($account, $method, $context);
++    $this->eventDispatcher->dispatch($account_cancel_event);
++
++    // After cancelling account, ensure that user is logged out.
++    if ($account->id() == \Drupal::currentUser()->id()) {
++      // Batch API stores data in the session, so use the finished operation to
++      // manipulate the current user's session ID.
++      $batch_builder = (new BatchBuilder())->setFinishCallback(static::class . '::regenerateSession');
++      batch_set($batch_builder->toArray());
++    }
++
++    // Batch processing is either handled via Form API or has to be invoked
++    // manually.
++  }
++
++  /**
++   * Provides a finished batch processing callback for cancelling user account.
++   *
++   * Note that this method is declared static to avoid serialization of a huge
++   * object by the batch API.
++   */
++  public static function regenerateSession(): void {
++    // Regenerate the user's session instead of calling session_destroy() as we
++    // want to preserve any messages that might have been set.
++    \Drupal::service('session')->migrate();
++  }
++
++}
+diff --git a/core/modules/user/src/AccountCancellationInterface.php b/core/modules/user/src/AccountCancellationInterface.php
+new file mode 100644
+index 00000000000..899cbe20388
+--- /dev/null
++++ b/core/modules/user/src/AccountCancellationInterface.php
+@@ -0,0 +1,23 @@
++<?php
++
++namespace Drupal\user;
++
++/**
++ * Interface of 'user.account_cancellation' service.
++ */
++interface AccountCancellationInterface {
++
++  /**
++   * Cancels a user account.
++   *
++   * @param \Drupal\user\UserInterface $account
++   *   The user account to be cancelled.
++   * @param string $method
++   *   The account cancellation method to use.
++   * @param array $context
++   *   (optional) Context array. Typically, an array of submitted form values as
++   *   this service is mostly consumed via form API.
++   */
++  public function cancel(UserInterface $account, string $method, array $context = []): void;
++
++}
+diff --git a/core/modules/user/src/Controller/UserController.php b/core/modules/user/src/Controller/UserController.php
+index d4c6ff42993..bf9e6a4ce70 100644
+--- a/core/modules/user/src/Controller/UserController.php
++++ b/core/modules/user/src/Controller/UserController.php
+@@ -9,6 +9,7 @@
+ use Drupal\Core\Datetime\DateFormatterInterface;
+ use Drupal\Core\Flood\FloodInterface;
+ use Drupal\Core\Url;
++use Drupal\user\AccountCancellationInterface;
+ use Drupal\user\Form\UserPasswordResetForm;
+ use Drupal\user\UserDataInterface;
+ use Drupal\user\UserInterface;
+@@ -59,6 +60,13 @@ class UserController extends ControllerBase {
+    */
+   protected $flood;
+
++  /**
++   * The account cancellation service.
++   *
++   * @var \Drupal\user\AccountCancellationInterface
++   */
++  protected AccountCancellationInterface $accountCancellation;
++
+   /**
+    * Constructs a UserController object.
+    *
+@@ -74,6 +82,10 @@ class UserController extends ControllerBase {
+    *   The flood service.
+    * @param \Drupal\Component\Datetime\TimeInterface|null $time
+    *   The time service.
++   * @param \Drupal\user\AccountCancellationInterface $account_cancellation
++   *   The account cancellation service.
++   *
++   * @see https://www.drupal.org/node/3279455
+    */
+   public function __construct(
+     DateFormatterInterface $date_formatter,
+@@ -82,6 +94,7 @@ public function __construct(
+     LoggerInterface $logger,
+     FloodInterface $flood,
+     protected ?TimeInterface $time = NULL,
++    AccountCancellationInterface $account_cancellation = NULL
+   ) {
+     $this->dateFormatter = $date_formatter;
+     $this->userStorage = $user_storage;
+@@ -92,6 +105,11 @@ public function __construct(
+       @trigger_error('Calling ' . __METHOD__ . ' without the $time argument is deprecated in drupal:10.3.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3112298', E_USER_DEPRECATED);
+       $this->time = \Drupal::service('datetime.time');
+     }
++    if (!$account_cancellation) {
++      @trigger_error('Calling ' . __METHOD__ . '() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455', E_USER_DEPRECATED);
++      $account_cancellation = \Drupal::service('user.account_cancellation');
++    }
++    $this->accountCancellation = $account_cancellation;
+   }
+
+   /**
+@@ -105,6 +123,7 @@ public static function create(ContainerInterface $container) {
+       $container->get('logger.factory')->get('user'),
+       $container->get('flood'),
+       $container->get('datetime.time'),
++      $container->get('user.account_cancellation')
+     );
+   }
+
+@@ -429,7 +448,7 @@ public function confirmCancel(UserInterface $user, $timestamp = 0, $hashed_pass
+         $edit = [
+           'user_cancel_notify' => $account_data['cancel_notify'] ?? $this->config('user.settings')->get('notify.status_canceled'),
+         ];
+-        user_cancel($edit, $user->id(), $account_data['cancel_method']);
++        $this->accountCancellation->cancel($user, $account_data['cancel_method'], $edit);
+         // Since user_cancel() is not invoked via Form API, batch processing
+         // needs to be invoked manually and should redirect to the front page
+         // after completion.
+diff --git a/core/modules/user/src/Event/AccountCancelEvent.php b/core/modules/user/src/Event/AccountCancelEvent.php
+new file mode 100644
+index 00000000000..f1a746463c4
+--- /dev/null
++++ b/core/modules/user/src/Event/AccountCancelEvent.php
+@@ -0,0 +1,87 @@
++<?php
++
++namespace Drupal\user\Event;
++
++use Drupal\Component\EventDispatcher\Event;
++use Drupal\user\UserInterface;
++
++/**
++ * Provides a user cancel event class.
++ *
++ * Subscribers are able to react on user account cancellation or implement their
++ * own cancellation logic. Also, by setting appropriate priories, they are able
++ * to suppress the execution of downstream subscribers, such as the default user
++ * account subscriber \Drupal\user\EventSubscriber\AccountCancelSubscriber.
++ *
++ * @see \Drupal\user\EventSubscriber\AccountCancelSubscriber
++ */
++class AccountCancelEvent extends Event {
++
++  /**
++   * The account to be cancelled.
++   *
++   * @var \Drupal\user\UserInterface
++   */
++  protected UserInterface $account;
++
++  /**
++   * The account cancellation method to use.
++   *
++   * @var string
++   */
++  protected string $method;
++
++  /**
++   * Context array. Typically, an array of submitted form values.
++   *
++   * @var array
++   */
++  protected array $context;
++
++  /**
++   * Constructs a new event instance.
++   *
++   * @param \Drupal\user\UserInterface $account
++   *   The user account to be cancelled.
++   * @param string $method
++   *   The account cancellation method to use.
++   * @param array $context
++   *   Context array. Typically, an array of submitted form values.
++   */
++  public function __construct(UserInterface $account, string $method, array $context) {
++    $this->account = $account;
++    $this->method = $method;
++    $this->context = $context;
++  }
++
++  /**
++   * Returns the user account to be cancelled.
++   *
++   * @return \Drupal\user\UserInterface
++   *   The user account to be cancelled.
++   */
++  public function getAccount(): UserInterface {
++    return $this->account;
++  }
++
++  /**
++   * Returns the account cancellation method to use.
++   *
++   * @return string
++   *   The account cancellation method to use.
++   */
++  public function getMethod(): string {
++    return $this->method;
++  }
++
++  /**
++   * Returns the context array. Usually an array of submitted form values.
++   *
++   * @return array
++   *   Context array. Typically, an array of submitted form values.
++   */
++  public function getContext(): array {
++    return $this->context;
++  }
++
++}
+diff --git a/core/modules/user/src/EventSubscriber/AccountCancelSubscriber.php b/core/modules/user/src/EventSubscriber/AccountCancelSubscriber.php
+new file mode 100644
+index 00000000000..65ea5d752bc
+--- /dev/null
++++ b/core/modules/user/src/EventSubscriber/AccountCancelSubscriber.php
+@@ -0,0 +1,112 @@
++<?php
++
++namespace Drupal\user\EventSubscriber;
++
++use Drupal\Core\Batch\BatchBuilder;
++use Drupal\Core\Session\AnonymousUserSession;
++use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Drupal\user\Event\AccountCancelEvent;
++use Drupal\user\UserInterface;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Subscribes to user cancellation event.
++ */
++class AccountCancelSubscriber implements EventSubscriberInterface {
++
++  use StringTranslationTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    return [
++      // Since batch and session API require a valid user account, the actual
++      // cancellation of a user account needs to happen last.
++      AccountCancelEvent::class => 'onUserAccountCancel',
++    ];
++  }
++
++  /**
++   * Acts on user account cancel event.
++   *
++   * @param \Drupal\user\Event\AccountCancelEvent $event
++   *   The user cancel event.
++   */
++  public function onUserAccountCancel(AccountCancelEvent $event): void {
++    $batch_builder = (new BatchBuilder())
++      ->setTitle(t('Cancelling user account'))
++      ->addOperation(static::class . '::doCancelAccount', [
++        $event->getAccount(),
++        $event->getMethod(),
++        $event->getContext(),
++      ]);
++    batch_set($batch_builder->toArray());
++  }
++
++  /**
++   * Cancels a user account.
++   *
++   * Note that this method is declared static to avoid serialization of a huge
++   * object by the batch API.
++   *
++   * @param \Drupal\user\UserInterface $account
++   *   The user account to be cancelled.
++   * @param string $method
++   *   The cancellation method.
++   * @param array $context
++   *   A context array. Typically, an array of submitted form values.
++   */
++  public static function doCancelAccount(UserInterface $account, string $method, array $context): void {
++    $logger = \Drupal::logger('user');
++    $messenger = \Drupal::messenger();
++
++    switch ($method) {
++      case 'user_cancel_block':
++      case 'user_cancel_block_unpublish':
++      default:
++        if (!in_array($method, ['user_cancel_block', 'user_cancel_block_unpublish'], TRUE)) {
++          @trigger_error("Using " . __METHOD__ . "() subscriber to handle user account cancellation methods other than user_cancel_block, user_cancel_block_unpublish, user_cancel_reassign and user_cancel_delete is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. The '$method' user account cancellation method has been used. Third-party modules should add their own subscriber to handle custom cancellation methods. See https://www.drupal.org/node/3279455", E_USER_DEPRECATED);
++        }
++
++        // Send account blocked notification if option was checked.
++        if (!empty($context['user_cancel_notify'])) {
++          _user_mail_notify('status_blocked', $account);
++        }
++        $account->block()->save();
++        $messenger->addStatus(t('Account %name has been disabled.', [
++          '%name' => $account->getDisplayName(),
++        ]));
++        $logger->notice('Blocked user: %name %email.', [
++          '%name' => $account->getAccountName(),
++          '%email' => '<' . $account->getEmail() . '>',
++        ]);
++        break;
++
++      case 'user_cancel_reassign':
++      case 'user_cancel_delete':
++        // Send account canceled notification if option was checked.
++        if (!empty($context['user_cancel_notify'])) {
++          _user_mail_notify('status_canceled', $account);
++        }
++        $account->delete();
++        $messenger->addStatus(t('Account %name has been deleted.', [
++          '%name' => $account->getDisplayName(),
++        ]));
++        $logger->notice('Deleted user: %name %email.', [
++          '%name' => $account->getAccountName(),
++          '%email' => '<' . $account->getEmail() . '>',
++        ]);
++    }
++
++    // After cancelling account, ensure that user is logged out. We can't
++    // destroy their session though, as we might have information in it, and we
++    // can't  regenerate it because batch API uses the session ID, we will
++    // regenerate it in \Drupal\user\AccountCancellation::regenerateSession().
++    // @see \Drupal\user\AccountCancellation::regenerateSession()
++    if ($account->id() == \Drupal::currentUser()->id()) {
++      \Drupal::currentUser()->setAccount(new AnonymousUserSession());
++    }
++  }
++
++}
+diff --git a/core/modules/user/src/Form/UserCancelForm.php b/core/modules/user/src/Form/UserCancelForm.php
+index 787339e07fd..976cbb1dcc6 100644
+--- a/core/modules/user/src/Form/UserCancelForm.php
++++ b/core/modules/user/src/Form/UserCancelForm.php
+@@ -2,8 +2,13 @@
+
+ namespace Drupal\user\Form;
+
++use Drupal\Component\Datetime\TimeInterface;
+ use Drupal\Core\Entity\ContentEntityConfirmFormBase;
++use Drupal\Core\Entity\EntityRepositoryInterface;
++use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+ use Drupal\Core\Form\FormStateInterface;
++use Drupal\user\AccountCancellationInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
+
+ /**
+  * Provides a confirmation form for cancelling user account.
+@@ -33,6 +38,48 @@ class UserCancelForm extends ContentEntityConfirmFormBase {
+    */
+   protected $entity;
+
++  /**
++   * The account cancellation service.
++   *
++   * @var \Drupal\user\AccountCancellationInterface
++   */
++  protected AccountCancellationInterface $accountCancellation;
++
++  /**
++   * Constructs a new form instance.
++   *
++   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
++   *   The entity repository service.
++   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
++   *   The entity type bundle service.
++   * @param \Drupal\Component\Datetime\TimeInterface $time
++   *   The time service.
++   * @param \Drupal\user\AccountCancellationInterface $account_cancellation
++   *   The account cancellation service.
++   *
++   * @see https://www.drupal.org/node/3279455
++   */
++  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, AccountCancellationInterface $account_cancellation = NULL) {
++    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
++    if (!$account_cancellation) {
++      @trigger_error('Calling ' . __METHOD__ . '() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455', E_USER_DEPRECATED);
++      $account_cancellation = \Drupal::service('user.account_cancellation');
++    }
++    $this->accountCancellation = $account_cancellation;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container): self {
++    return new static(
++      $container->get('entity.repository'),
++      $container->get('entity_type.bundle.info'),
++      $container->get('datetime.time'),
++      $container->get('user.account_cancellation')
++    );
++  }
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -137,7 +184,7 @@ public function submitForm(array &$form, FormStateInterface $form_state) {
+     // privileges, no confirmation mail shall be sent, and the user does not
+     // attempt to cancel the own account.
+     if (!$form_state->isValueEmpty('access') && $form_state->isValueEmpty('user_cancel_confirm') && $this->entity->id() != $this->currentUser()->id()) {
+-      user_cancel($form_state->getValues(), $this->entity->id(), $form_state->getValue('user_cancel_method'));
++      $this->accountCancellation->cancel($this->entity, $form_state->getValue('user_cancel_method'), $form_state->getValues());
+
+       $form_state->setRedirectUrl($this->entity->toUrl('collection'));
+     }
+diff --git a/core/modules/user/src/Form/UserMultipleCancelConfirm.php b/core/modules/user/src/Form/UserMultipleCancelConfirm.php
+index f0463686a80..0e447c9aafa 100644
+--- a/core/modules/user/src/Form/UserMultipleCancelConfirm.php
++++ b/core/modules/user/src/Form/UserMultipleCancelConfirm.php
+@@ -8,6 +8,7 @@
+ use Drupal\Core\Messenger\MessengerInterface;
+ use Drupal\Core\Url;
+ use Drupal\Core\TempStore\PrivateTempStoreFactory;
++use Drupal\user\AccountCancellationInterface;
+ use Drupal\user\UserStorageInterface;
+ use Symfony\Component\DependencyInjection\ContainerInterface;
+
+@@ -39,6 +40,13 @@ class UserMultipleCancelConfirm extends ConfirmFormBase {
+    */
+   protected $entityTypeManager;
+
++  /**
++   * The account cancellation service.
++   *
++   * @var \Drupal\user\AccountCancellationInterface
++   */
++  protected AccountCancellationInterface $accountCancellation;
++
+   /**
+    * Constructs a new UserMultipleCancelConfirm.
+    *
+@@ -48,11 +56,20 @@ class UserMultipleCancelConfirm extends ConfirmFormBase {
+    *   The user storage.
+    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+    *   The entity type manager.
++   * @param \Drupal\user\AccountCancellationInterface $account_cancellation
++   *   The account cancellation service.
++   *
++   * @see https://www.drupal.org/node/3279455
+    */
+-  public function __construct(PrivateTempStoreFactory $temp_store_factory, UserStorageInterface $user_storage, EntityTypeManagerInterface $entity_type_manager) {
++  public function __construct(PrivateTempStoreFactory $temp_store_factory, UserStorageInterface $user_storage, EntityTypeManagerInterface $entity_type_manager, AccountCancellationInterface $account_cancellation = NULL) {
+     $this->tempStoreFactory = $temp_store_factory;
+     $this->userStorage = $user_storage;
+     $this->entityTypeManager = $entity_type_manager;
++    if (!$account_cancellation) {
++      @trigger_error('Calling ' . __METHOD__ . '() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455', E_USER_DEPRECATED);
++      $account_cancellation = \Drupal::service('user.account_cancellation');
++    }
++    $this->accountCancellation = $account_cancellation;
+   }
+
+   /**
+@@ -62,7 +79,8 @@ public static function create(ContainerInterface $container) {
+     return new static(
+       $container->get('tempstore.private'),
+       $container->get('entity_type.manager')->getStorage('user'),
+-      $container->get('entity_type.manager')
++      $container->get('entity_type.manager'),
++      $container->get('user.account_cancellation')
+     );
+   }
+
+@@ -206,14 +224,14 @@ public function submitForm(array &$form, FormStateInterface $form_state) {
+         if ($uid <= 1) {
+           continue;
+         }
++        // The $user global is not a complete user entity, so load the full
++        // entity.
++        $account = $this->userStorage->load($uid);
+         // Prevent user administrators from deleting themselves without confirmation.
+         if ($uid == $current_user_id) {
+           $admin_form_mock = [];
+           $admin_form_state = $form_state;
+           $admin_form_state->unsetValue('user_cancel_confirm');
+-          // The $user global is not a complete user entity, so load the full
+-          // entity.
+-          $account = $this->userStorage->load($uid);
+           $admin_form = $this->entityTypeManager->getFormObject('user', 'cancel');
+           $admin_form->setEntity($account);
+           // Calling this directly required to init form object with $account.
+@@ -221,7 +239,7 @@ public function submitForm(array &$form, FormStateInterface $form_state) {
+           $admin_form->submitForm($admin_form_mock, $admin_form_state);
+         }
+         else {
+-          user_cancel($form_state->getValues(), $uid, $form_state->getValue('user_cancel_method'));
++          $this->accountCancellation->cancel($account, $form_state->getValue('user_cancel_method'), $form_state->getValues());
+         }
+       }
+     }
+diff --git a/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.info.yml b/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.info.yml
+new file mode 100644
+index 00000000000..bfad595dde7
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.info.yml
+@@ -0,0 +1,6 @@
++name: 'User cancel deprecated test'
++type: module
++description: 'Support module for testing deprecation of user cancel custom method.'
++package: Testing
++version: VERSION
++core_version_requirement: ^10
+diff --git a/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.module b/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.module
+new file mode 100644
+index 00000000000..1a83bd5f7c6
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_deprecated_test/user_cancel_deprecated_test.module
+@@ -0,0 +1,27 @@
++<?php
++
++/**
++ * @file
++ * Contains user_cancel_deprecated_test.module.
++ */
++
++use Drupal\user\UserInterface;
++
++/**
++ * Implements hook_user_cancel_methods_alter().
++ */
++function user_cancel_deprecated_test_user_cancel_methods_alter(array &$methods): void {
++  $methods['user_cancel_test_deprecated'] = [
++    'title' => 'User cancel test (deprecated)',
++    'description' => 'User cancel test method (deprecated)',
++  ];
++}
++
++/**
++ * Implements hook_user_cancel().
++ */
++function user_cancel_deprecated_test_user_cancel(array $edit, UserInterface $account, string $method): void {
++  if ($method === 'user_cancel_test_deprecated') {
++    \Drupal::messenger()->addStatus('Custom user deprecated cancel method executed.');
++  }
++}
+diff --git a/core/modules/user/tests/modules/user_cancel_test/src/UserCancelTestAccountCancelSubscriber.php b/core/modules/user/tests/modules/user_cancel_test/src/UserCancelTestAccountCancelSubscriber.php
+new file mode 100644
+index 00000000000..fe386c78995
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_test/src/UserCancelTestAccountCancelSubscriber.php
+@@ -0,0 +1,37 @@
++<?php
++
++namespace Drupal\user_cancel_test;
++
++use Drupal\user\Event\AccountCancelEvent;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Performs user_cancel_test module operations when a user account is cancelled.
++ */
++class UserCancelTestAccountCancelSubscriber implements EventSubscriberInterface {
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    return [
++      // Act before all Drupal core subscribers.
++      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
++      AccountCancelEvent::class => ['onUserAccountCancel', 50],
++    ];
++  }
++
++  /**
++   * Acts on user account cancel event.
++   *
++   * @param \Drupal\user\Event\AccountCancelEvent $event
++   *   The user cancel event.
++   */
++  public function onUserAccountCancel(AccountCancelEvent $event): void {
++    if ($event->getMethod() === 'user_cancel_test') {
++      \Drupal::messenger()->addStatus('Custom user cancel method executed.');
++      $event->stopPropagation();
++    }
++  }
++
++}
+diff --git a/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.info.yml b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.info.yml
+new file mode 100644
+index 00000000000..5532be1a1cc
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.info.yml
+@@ -0,0 +1,6 @@
++name: 'User cancel test'
++type: module
++description: 'Support module for testing user cancel custom method.'
++package: Testing
++version: VERSION
++core_version_requirement: ^9 || ^10
+diff --git a/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.module b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.module
+new file mode 100644
+index 00000000000..ddbe79c16d8
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.module
+@@ -0,0 +1,16 @@
++<?php
++
++/**
++ * @file
++ * Contains user_cancel_test.module.
++ */
++
++/**
++ * Implements hook_user_cancel_methods_alter().
++ */
++function user_cancel_test_user_cancel_methods_alter(array &$methods): void {
++  $methods['user_cancel_test'] = [
++    'title' => 'User cancel test',
++    'description' => 'User cancel test method',
++  ];
++}
+diff --git a/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.services.yml b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.services.yml
+new file mode 100644
+index 00000000000..4d3487384ec
+--- /dev/null
++++ b/core/modules/user/tests/modules/user_cancel_test/user_cancel_test.services.yml
+@@ -0,0 +1,6 @@
++services:
++
++  user_cancel_test.account_cancel.subscriber:
++    class: Drupal\user_cancel_test\UserCancelTestAccountCancelSubscriber
++    tags:
++      - { name: event_subscriber }
+diff --git a/core/modules/user/tests/src/Functional/UserCancelCustomMethodTest.php b/core/modules/user/tests/src/Functional/UserCancelCustomMethodTest.php
+new file mode 100644
+index 00000000000..b373d7a38e9
+--- /dev/null
++++ b/core/modules/user/tests/src/Functional/UserCancelCustomMethodTest.php
+@@ -0,0 +1,64 @@
++<?php
++
++namespace Drupal\Tests\user\Functional;
++
++use Drupal\Core\Test\AssertMailTrait;
++use Drupal\Tests\BrowserTestBase;
++
++/**
++ * Tests user cancellation with a custom method.
++ *
++ * @group user
++ */
++class UserCancelCustomMethodTest extends BrowserTestBase {
++
++  use AssertMailTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = ['user_cancel_test'];
++
++  /**
++   * {@inheritdoc}
++   */
++  protected $defaultTheme = 'stark';
++
++  /**
++   * Tests user cancellation with a custom method.
++   */
++  public function testUserCancelCustomMethod(): void {
++    $account = $this->createUser([
++      'cancel account',
++      'select account cancellation method',
++    ]);
++    $this->drupalLogin($account);
++    $this->drupalGet($account->toUrl('edit-form'));
++    $page = $this->getSession()->getPage();
++    $page->clickLink('Cancel account');
++
++    // Chose the custom cancellation method.
++    $page->selectFieldOption('user_cancel_method', 'user_cancel_test');
++    $page->pressButton('Confirm');
++
++    $this->clickConfirmationLinkFomMail();
++
++    // Check that the custom user cancellation has been executed but not the
++    // Drupal core cancellation.
++    // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
++    // @see \Drupal\user_cancel_test\UserCancelTestAccountCancelSubscriber::onUserAccountCancel()
++    $this->assertSession()->pageTextContains('Custom user cancel method executed.');
++    $this->assertSession()->pageTextNotContains("{$account->getDisplayName()} has been disabled.");
++  }
++
++  /**
++   * Clicks on the confirmation link sent by email.
++   */
++  protected function clickConfirmationLinkFomMail(): void {
++    $mails = $this->getMails();
++    $mail = reset($mails);
++    preg_match('#http.*#', $mail['body'], $found);
++    $this->drupalGet($found[0]);
++  }
++
++}
+diff --git a/core/modules/user/tests/src/Kernel/UserDeprecatedCancelCustomMethodTest.php b/core/modules/user/tests/src/Kernel/UserDeprecatedCancelCustomMethodTest.php
+new file mode 100644
+index 00000000000..f5eb641e86c
+--- /dev/null
++++ b/core/modules/user/tests/src/Kernel/UserDeprecatedCancelCustomMethodTest.php
+@@ -0,0 +1,105 @@
++<?php
++
++namespace Drupal\Tests\user\Kernel;
++
++use Drupal\KernelTests\KernelTestBase;
++use Drupal\Tests\user\Traits\UserCreationTrait;
++use Drupal\user\Controller\UserController;
++use Drupal\user\Form\UserCancelForm;
++use Drupal\user\Form\UserMultipleCancelConfirm;
++
++/**
++ * Tests deprecation of procedural custom user account cancelling method.
++ *
++ * @group user
++ * @group legacy
++ */
++class UserDeprecatedCancelCustomMethodTest extends KernelTestBase {
++
++  use UserCreationTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = [
++    'system',
++    'user',
++    'user_cancel_deprecated_test',
++    // In these modules, the hook has been previously implemented.
++    'comment',
++    'history',
++    'node',
++  ];
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++    $this->installSchema('system', ['sequences']);
++    $this->installEntitySchema('user');
++  }
++
++  /**
++   * Tests hook_user_cancel() hook deprecation.
++   */
++  public function testHookDeprecation(): void {
++    $this->expectDeprecation('The deprecated hook hook_user_cancel() is implemented in these functions: user_cancel_deprecated_test_user_cancel(). The hook is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. In order to act on user account cancellation provide an event subscriber that listens to the \Drupal\user\Event\AccountCancelEvent event. The event subscriber can be defined with a priority higher than the core subscribers in order to cancel them by using AccountCancelEvent::stopPropagation(). See https://www.drupal.org/node/3279455');
++    $this->container->get('user.account_cancellation')->cancel($this->createUser(), 'user_cancel_test_deprecated');
++
++    $batch =& batch_get();
++    // Bypass the progress bar and redirect.
++    $batch['progressive'] = FALSE;
++    $this->expectDeprecation("Using Drupal\user\EventSubscriber\AccountCancelSubscriber::doCancelAccount() subscriber to handle user account cancellation methods other than user_cancel_block, user_cancel_block_unpublish, user_cancel_reassign and user_cancel_delete is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. The 'user_cancel_test_deprecated' user account cancellation method has been used. Third-party modules should add their own subscriber to handle custom cancellation methods. See https://www.drupal.org/node/3279455");
++    batch_process();
++  }
++
++  /**
++   * Tests deprecation of procedural code.
++   *
++   * @covers \user_cancel
++   * @covers \_user_cancel
++   * @covers \_user_cancel_session_regenerate
++   */
++  public function testProceduralCodeDeprecations(): void {
++    $this->expectDeprecation("user_cancel is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Use the method ::cancel() from the 'user.account_cancellation' service instead. See https://www.drupal.org/node/3279455");
++    user_cancel([], $this->createUser()->id(), 'abc');
++    $this->expectDeprecation('_user_cancel is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use \Drupal\user\EventSubscriber\AccountCancelSubscriber::doCancelAccount(). See https://www.drupal.org/node/3279455');
++    _user_cancel([], $this->createUser(), 'abc');
++    $this->expectDeprecation('_user_cancel_session_regenerate() is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use \Drupal\user\AccountCancellation::regenerateSession(). See https://www.drupal.org/node/3279455');
++    _user_cancel_session_regenerate();
++  }
++
++  /**
++   * Tests constructor parameter additions deprecation messages.
++   *
++   * @covers \Drupal\user\Controller\UserController::__construct
++   * @covers \Drupal\user\Form\UserCancelForm::__construct
++   * @covers \Drupal\user\Form\UserMultipleCancelConfirm::__construct
++   */
++  public function testConstructorParamAdditionsDeprecationMessages(): void {
++    $this->expectDeprecation('Calling Drupal\user\Controller\UserController::__construct() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455');
++    new UserController(
++      $this->container->get('date.formatter'),
++      $this->container->get('entity_type.manager')->getStorage('user'),
++      $this->container->get('user.data'),
++      $this->container->get('logger.factory')->get('user'),
++      $this->container->get('flood')
++    );
++
++    $this->expectDeprecation('Calling Drupal\user\Form\UserCancelForm::__construct() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455');
++    new UserCancelForm(
++      $this->container->get('entity.repository'),
++      $this->container->get('entity_type.bundle.info'),
++      $this->container->get('datetime.time')
++    );
++
++    $this->expectDeprecation('Calling Drupal\user\Form\UserMultipleCancelConfirm::__construct() without the $account_cancellation argument is deprecated in drupal:10.0.0 and it will be required in drupal:11.0.0. See https://www.drupal.org/node/3279455');
++    new UserMultipleCancelConfirm(
++      $this->container->get('tempstore.private'),
++      $this->container->get('entity_type.manager')->getStorage('user'),
++      $this->container->get('entity_type.manager')
++    );
++  }
++
++}
+diff --git a/core/modules/user/user.api.php b/core/modules/user/user.api.php
+index 13fc647dc7c..1bc2217605b 100644
+--- a/core/modules/user/user.api.php
++++ b/core/modules/user/user.api.php
+@@ -36,6 +36,13 @@
+  * @param string $method
+  *   The account cancellation method.
+  *
++ * @deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. In order to
++ *   act on user account cancellation provide an event subscriber that listens
++ *   to the \Drupal\user\Event\AccountCancelEvent event. The event subscriber
++ *   can be defined with a priority higher than the core subscribers in order to
++ *   cancel them by using AccountCancelEvent::stopPropagation().
++ *
++ * @see https://www.drupal.org/node/3279455
+  * @see user_cancel_methods()
+  * @see hook_user_cancel_methods_alter()
+  */
+diff --git a/core/modules/user/user.module b/core/modules/user/user.module
+index 9fafc8f63eb..f65314c1a0b 100644
+--- a/core/modules/user/user.module
++++ b/core/modules/user/user.module
+@@ -11,7 +11,6 @@
+ use Drupal\Component\Utility\Unicode;
+ use Drupal\Core\Access\AccessibleInterface;
+ use Drupal\Core\Asset\AttachedAssetsInterface;
+-use Drupal\Core\Batch\BatchBuilder;
+ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+ use Drupal\Core\Entity\EntityInterface;
+ use Drupal\Core\Form\FormStateInterface;
+@@ -24,8 +23,9 @@
+ use Drupal\image\Plugin\Field\FieldType\ImageItem;
+ use Drupal\filter\FilterFormatInterface;
+ use Drupal\system\Entity\Action;
++use Drupal\user\AccountCancellation;
+ use Drupal\user\Entity\Role;
+-use Drupal\user\Entity\User;
++use Drupal\user\EventSubscriber\AccountCancelSubscriber;
+ use Drupal\user\RoleInterface;
+ use Drupal\user\UserInterface;
+
+@@ -606,47 +606,15 @@ function user_pass_rehash(UserInterface $account, $timestamp) {
+  * @param string $method
+  *   The account cancellation method to use.
+  *
+- * @see _user_cancel()
++ * @deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Use the
++ *   method ::cancel() from the 'user.account_cancellation' service instead.
++ *
++ * @see https://www.drupal.org/node/3279455
+  */
+ function user_cancel($edit, $uid, $method) {
+-  $account = User::load($uid);
+-
+-  if (!$account) {
+-    \Drupal::messenger()->addError(t('The user account %id does not exist.', ['%id' => $uid]));
+-    \Drupal::logger('user')->error('Attempted to cancel non-existing user account: %id.', ['%id' => $uid]);
+-    return;
+-  }
+-
+-  // Initialize batch (to set title).
+-  $batch_builder = (new BatchBuilder())
+-    ->setTitle(t('Cancelling account'));
+-  batch_set($batch_builder->toArray());
+-
+-  // When the 'user_cancel_delete' method is used, user_delete() is called,
+-  // which invokes hook_ENTITY_TYPE_predelete() and hook_ENTITY_TYPE_delete()
+-  // for the user entity. Modules should use those hooks to respond to the
+-  // account deletion.
+-  if ($method != 'user_cancel_delete') {
+-    // Allow modules to add further sets to this batch.
+-    \Drupal::moduleHandler()->invokeAll('user_cancel', [$edit, $account, $method]);
+-  }
+-
+-  // Finish the batch and actually cancel the account.
+-  $batch_builder = (new BatchBuilder())
+-    ->setTitle(t('Cancelling user account'))
+-    ->addOperation('_user_cancel', [$edit, $account, $method]);
+-
+-  // After cancelling account, ensure that user is logged out.
+-  if ($account->id() == \Drupal::currentUser()->id()) {
+-    // Batch API stores data in the session, so use the finished operation to
+-    // manipulate the current user's session id.
+-    $batch_builder->setFinishCallback('_user_cancel_session_regenerate');
+-  }
+-
+-  batch_set($batch_builder->toArray());
+-
+-  // Batch processing is either handled via Form API or has to be invoked
+-  // manually.
++  @trigger_error("user_cancel is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Use the method ::cancel() from the 'user.account_cancellation' service instead. See https://www.drupal.org/node/3279455", E_USER_DEPRECATED);
++  $account = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
++  \Drupal::service('user.account_cancellation')->cancel($account, $method, $edit);
+ }
+
+ /**
+@@ -663,44 +631,14 @@ function user_cancel($edit, $uid, $method) {
+  * @param string $method
+  *   The account cancellation method to use.
+  *
+- * @see user_cancel()
++ * @deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use
++ *   \Drupal\user\EventSubscriber\AccountCancelSubscriber::doCancelAccount().
++ *
++ * @see https://www.drupal.org/node/3279455
+  */
+ function _user_cancel($edit, $account, $method) {
+-  $logger = \Drupal::logger('user');
+-
+-  switch ($method) {
+-    case 'user_cancel_block':
+-    case 'user_cancel_block_unpublish':
+-    default:
+-      // Send account blocked notification if option was checked.
+-      if (!empty($edit['user_cancel_notify'])) {
+-        _user_mail_notify('status_blocked', $account);
+-      }
+-      $account->block();
+-      $account->save();
+-      \Drupal::messenger()->addStatus(t('Account %name has been disabled.', ['%name' => $account->getDisplayName()]));
+-      $logger->notice('Blocked user: %name %email.', ['%name' => $account->getAccountName(), '%email' => '<' . $account->getEmail() . '>']);
+-      break;
+-
+-    case 'user_cancel_reassign':
+-    case 'user_cancel_delete':
+-      // Send account canceled notification if option was checked.
+-      if (!empty($edit['user_cancel_notify'])) {
+-        _user_mail_notify('status_canceled', $account);
+-      }
+-      $account->delete();
+-      \Drupal::messenger()->addStatus(t('Account %name has been deleted.', ['%name' => $account->getDisplayName()]));
+-      $logger->notice('Deleted user: %name %email.', ['%name' => $account->getAccountName(), '%email' => '<' . $account->getEmail() . '>']);
+-      break;
+-  }
+-
+-  // After cancelling account, ensure that user is logged out. We can't destroy
+-  // their session though, as we might have information in it, and we can't
+-  // regenerate it because batch API uses the session ID, we will regenerate it
+-  // in _user_cancel_session_regenerate().
+-  if ($account->id() == \Drupal::currentUser()->id()) {
+-    \Drupal::currentUser()->setAccount(new AnonymousUserSession());
+-  }
++  @trigger_error('_user_cancel is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use \Drupal\user\EventSubscriber\AccountCancelSubscriber::doCancelAccount(). See https://www.drupal.org/node/3279455', E_USER_DEPRECATED);
++  AccountCancelSubscriber::doCancelAccount($account, $method, $edit);
+ }
+
+ /**
+@@ -708,12 +646,14 @@ function _user_cancel($edit, $account, $method) {
+  *
+  * Finished batch processing callback for cancelling a user account.
+  *
+- * @see user_cancel()
++ * @deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use
++ *   \Drupal\user\AccountCancellation::regenerateSession().
++ *
++ * @see https://www.drupal.org/node/3279455
+  */
+ function _user_cancel_session_regenerate() {
+-  // Regenerate the users session instead of calling session_destroy() as we
+-  // want to preserve any messages that might have been set.
+-  \Drupal::service('session')->migrate();
++  @trigger_error('_user_cancel_session_regenerate() is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. Instead, use \Drupal\user\AccountCancellation::regenerateSession(). See https://www.drupal.org/node/3279455', E_USER_DEPRECATED);
++  AccountCancellation::regenerateSession();
+ }
+
+ /**
+diff --git a/core/modules/user/user.services.yml b/core/modules/user/user.services.yml
+index ec34738d992..85204da23cc 100644
+--- a/core/modules/user/user.services.yml
++++ b/core/modules/user/user.services.yml
+@@ -69,6 +69,13 @@ services:
+   logger.channel.user:
+     parent: logger.channel_base
+     arguments: ['user']
++  user.account_cancellation:
++    class: Drupal\user\AccountCancellation
++    arguments: ['@module_handler', '@event_dispatcher']
++  user.account_cancel.subscriber:
++    class: Drupal\user\EventSubscriber\AccountCancelSubscriber
++    tags:
++      - { name: event_subscriber }
+   Drupal\user\ModulePermissionsLinkHelper: '@user.module_permissions_link_helper'
+   user.module_permissions_link_helper:
+     class: Drupal\user\ModulePermissionsLinkHelper

--- a/web/modules/asu_modules/asu_secure_superadmin/src/EventSubscriber/CustomUserCancelSubscriber.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/EventSubscriber/CustomUserCancelSubscriber.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\asu_secure_superadmin\EventSubscriber;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\user\Event\AccountCancelEvent;
+use Drupal\user\EventSubscriber\AccountCancelSubscriber;
+use Drupal\user\UserInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Custom user account cancellation subscriber.
+ */
+class CustomUserCancelSubscriber extends AccountCancelSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      // Act before all Drupal core subscribers.
+      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
+      AccountCancelEvent::class => ['onUserAccountCancel', 55],
+    ];
+  }
+
+  /**
+   * Acts on user account cancel event.
+   *
+   * @param \Drupal\user\Event\AccountCancelEvent $event
+   *   The user cancel event.
+   */
+  public function onUserAccountCancel(AccountCancelEvent $event): void {
+    $batch_builder = (new BatchBuilder())
+      ->setTitle(t('Cancelling user account'))
+      ->addOperation(static::class . '::doCustomCancelAccount', [
+        $event->getAccount(),
+        $event->getMethod(),
+        $event->getContext(),
+      ]);
+    batch_set($batch_builder->toArray());
+    $event->stopPropagation();
+  }
+
+  /**
+   * Cancels a user account.
+   *
+   * Note that this method is declared static to avoid serialization of a huge
+   * object by the batch API.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   The user account to be cancelled.
+   * @param string $method
+   *   The cancellation method.
+   * @param array $context
+   *   A context array. Typically, an array of submitted form values.
+   */
+  public static function doCustomCancelAccount(UserInterface $account, string $method, array $context): void {
+    $logger = \Drupal::logger('user');
+    $messenger = \Drupal::messenger();
+
+    switch ($method) {
+      case 'user_cancel_block':
+      case 'user_cancel_block_unpublish':
+      default:
+        if (!in_array($method, [
+          'user_cancel_block',
+          'user_cancel_block_unpublish',
+        ], TRUE)) {
+          @trigger_error("Using " . __METHOD__ . "() subscriber to handle user account cancellation methods other than user_cancel_block, user_cancel_block_unpublish, user_cancel_reassign and user_cancel_delete is deprecated in drupal:10.0.0 and is removed from drupal:11.0.0. The '$method' user account cancellation method has been used. Third-party modules should add their own subscriber to handle custom cancellation methods. See https://www.drupal.org/node/3279455", E_USER_DEPRECATED);
+        }
+
+        // Send account blocked notification if option was checked.
+        if (!empty($context['user_cancel_notify'])) {
+          _user_mail_notify('status_blocked', $account);
+        }
+        $account->block()->save();
+        $messenger->addStatus(t('Account %name has been disabled.', [
+          '%name' => $account->getDisplayName(),
+        ]));
+        $logger->notice('Blocked user: %name %email.', [
+          '%name' => $account->getAccountName(),
+          '%email' => '<' . $account->getEmail() . '>',
+        ]);
+        break;
+
+      case 'user_cancel_reassign':
+      case 'user_cancel_delete':
+        // Send account canceled notification if option was checked.
+        if (!empty($context['user_cancel_notify'])) {
+          _user_mail_notify('status_canceled', $account);
+        }
+        $account->delete();
+        $messenger->addStatus(t('Account %name has been deleted.', [
+          '%name' => $account->getDisplayName(),
+        ]));
+        $logger->notice('Deleted user: %name %email.', [
+          '%name' => $account->getAccountName(),
+          '%email' => '<' . $account->getEmail() . '>',
+        ]);
+        break;
+
+      case 'user_cancel_block_reassign_content_admin':
+        // Send account blocked notification if option was checked.
+        if (!empty($context['user_cancel_notify'])) {
+          _user_mail_notify('status_blocked', $account);
+        }
+        $account->block()->save();
+        $messenger->addStatus(t('Account %name has been disabled.', [
+          '%name' => $account->getDisplayName(),
+        ]));
+        $logger->notice('Blocked user: %name %email.', [
+          '%name' => $account->getAccountName(),
+          '%email' => '<' . $account->getEmail() . '>',
+        ]);
+        break;
+    }
+
+    // After cancelling account, ensure that user is logged out. We can't
+    // destroy their session though, as we might have information in it, and we
+    // can't  regenerate it because batch API uses the session ID, we will
+    // regenerate it in \Drupal\user\AccountCancellation::regenerateSession().
+    // @see \Drupal\user\AccountCancellation::regenerateSession()
+    if ($account->id() == \Drupal::currentUser()->id()) {
+      \Drupal::currentUser()->setAccount(new AnonymousUserSession());
+    }
+  }
+
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/src/EventSubscriber/EntityAccountCancelSubscriber.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/EventSubscriber/EntityAccountCancelSubscriber.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\asu_secure_superadmin\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\user\Event\AccountCancelEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\asu_secure_superadmin\Services\EntityMassUpdateService;
+
+/**
+ * Performs mass entity operations when a user account is cancelled.
+ */
+class EntityAccountCancelSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * The entity mass update service.
+   *
+   * @var \Drupal\asu_secure_superadmin\Services\EntityMassUpdateService
+   */
+  protected EntityMassUpdateService $entityMassUpdateService;
+
+  /**
+   * Constructs a new EntityAccountCancelSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler service.
+   * @param \Drupal\asu_secure_superadmin\Services\EntityMassUpdateService $entityMassUpdateService
+   *   The entity mass update service.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $moduleHandler, EntityMassUpdateService $entityMassUpdateService) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->moduleHandler = $moduleHandler;
+    $this->entityMassUpdateService = $entityMassUpdateService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      // Act before AccountCancelSubscriber::onUserAccountCancel()
+      // @see \Drupal\user\EventSubscriber\AccountCancelSubscriber::onUserAccountCancel()
+      AccountCancelEvent::class => ['onUserAccountCancel', 60],
+    ];
+  }
+
+  /**
+   * Acts on user account cancel event.
+   *
+   * @param \Drupal\user\Event\AccountCancelEvent $event
+   *   The user cancel event.
+   */
+  public function onUserAccountCancel(AccountCancelEvent $event): void {
+    $method = $event->getMethod();
+    $context = $event->getContext();
+    if ($method === 'user_cancel_block_reassign_content_admin') {
+      $new_uid = $context['reassign_content_admin'];
+      // Entities to update.
+      $entity_types = ['media', 'node', 'webform_submission', 'comment'];
+      foreach ($entity_types as $entity_type) {
+        $this->entityMassUpdateService->entityMassUpdate($entity_type, $event->getAccount(), [
+          'uid' => $new_uid,
+          'revision_uid' => $new_uid,
+        ], NULL, TRUE);
+      }
+    }
+  }
+
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Form/SettingsForm.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Form/SettingsForm.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\asu_secure_superadmin\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * Configure Asu secure superadmin settings for this site.
+ */
+final class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'asu_secure_superadmin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['asu_secure_superadmin.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    parent::buildForm($form, $form_state);
+    $form['example'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('<p>Click the button below to secure the SuperAdmin (user 1) account on this website.<br /><small>If the button is disabled, the account has already been secured.</small></p>'),
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Secure Superadmin'),
+      '#button_type' => 'primary',
+    ];
+    $user = User::load(1);
+    $disable_submit = ($user && $user->getAccountName() === 'etsuper');
+    // Disable the submit button if the user with uid1 is named etsuper
+    $form['actions']['submit']['#disabled'] = $disable_submit;
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+    try {
+      \Drupal::service('asu_secure_superadmin.change_super_admin_service')->changeSuperAdmin();
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('asu_secure_superadmin')->error($e->getMessage());
+      \Drupal::messenger()->addError($e->getMessage());
+      return;
+    }
+    \Drupal::messenger()->addMessage('The super admin account has been secured.');
+  }
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\asu_secure_superadmin\Services;
+
+use Drupal\cas\Service\CasUserManager;
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\user\Entity\User;
+use Drupal\user\Event\AccountCancelEvent;
+use Drupal\Core\Password\DefaultPasswordGenerator;
+
+/**
+ * Change the super admin (uid 1) to a new user.
+ */
+class ChangeSuperAdminService {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   */
+  protected $eventDispatcher;
+
+  /**
+   * The CAS user manager.
+   *
+   * @var \Drupal\cas\Service\CasUserManager
+   */
+  protected $casUserManager;
+
+  /**
+   * The password generator.
+   *
+   * @var \Drupal\Core\Password\DefaultPasswordGenerator
+   */
+  protected $passwordGenerator;
+
+  /**
+   * Constructs a new ChangeSuperAdminService object.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, ContainerAwareEventDispatcher $eventDispatcher, CasUserManager $casUserManager, DefaultPasswordGenerator $passwordGenerator) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->eventDispatcher = $eventDispatcher;
+    $this->casUserManager = $casUserManager;
+    $this->passwordGenerator = $passwordGenerator;
+  }
+
+  /**
+   * Change the super admin (uid 1) to a new user.
+   *
+   * @throws \Exception
+   */
+  public function changeSuperAdmin() :void {
+    /** @var \Drupal\user\Entity\User $user1 */
+    $user1 = User::load(1);
+    $original_name = $user1->get('name')->value;
+    // Duplicate the user entity and trigger the event to reassign content.
+    /** @var \Drupal\user\Entity\User $newUser */
+    $newUser = $user1->createDuplicate();
+    $newUser->isNew();
+    $newUser->set('uid', NULL);
+    $user1->set('name', 'etsuper');
+    $user1->set('mail', 'DL.WG.ET.WebPlatformsAcquia@exchange.asu.edu');
+    // Remove roles from the old user.
+    $roles = $user1->getRoles();
+    foreach ($roles as $role) {
+      $user1->removeRole($role);
+    }
+    $newPassword = $this->passwordGenerator->generate(15);
+    $user1->set('pass', $newPassword);
+    $oldCasUsername = $this->casUserManager->getCasUsernameForAccount($user1->id()) ? $this->casUserManager->removeCasUsernameForAccount($user1) : FALSE;
+    $user1->save();
+    $newUser->save();
+    if ($oldCasUsername) {
+      $this->casUserManager->setCasUsernameForAccount($newUser, $oldCasUsername);
+    }
+    // Reload the newUser object to get the new uid.
+    $newUserReloaded = user_load_by_name($original_name);
+    $method = 'user_cancel_block_reassign_content_admin';
+    $context = [
+      'user_cancel_notify' => FALSE,
+      'reassign_content_admin' => $newUserReloaded->id(),
+    ];
+    $this->triggerAccountCancelEvent($user1, $method, $context);
+  }
+
+  /**
+   * Trigger the AccountCancelEvent.
+   *
+   * @param \Drupal\user\Entity\User $account
+   *   The user account to be cancelled.
+   * @param string $method
+   *   The cancellation method.
+   * @param array $context
+   *   A context array. Typically, an array of submitted form values.
+   */
+  public function triggerAccountCancelEvent(User $account, string $method, array $context = []): void {
+
+    // Create the AccountCancelEvent.
+    $event = new AccountCancelEvent($account, $method, $context);
+
+    // Dispatch the event.
+    $this->eventDispatcher->dispatch($event, AccountCancelEvent::class);
+  }
+
+}

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
@@ -84,8 +84,12 @@ class ChangeSuperAdminService {
     // Reload the newUser object to get the new uid.
     $newUserReloaded = user_load_by_name($original_name);
     $roles = $newUserReloaded->getRoles();
-    if (!in_array('administrator', $roles)) {
-      $newUserReloaded->addRole('administrator');
+    if (in_array('administrator', $roles)) {
+      $newUserReloaded->removeRole('administrator');
+      $newUserReloaded->save();
+    }
+    if (!in_array('site_builder', $roles)) {
+      $newUserReloaded->addRole('site_builder');
       $newUserReloaded->save();
     }
     $method = 'user_cancel_block_reassign_content_admin';

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
@@ -67,7 +67,7 @@ class ChangeSuperAdminService {
     $newUser->isNew();
     $newUser->set('uid', NULL);
     $user1->set('name', 'etsuper');
-    $user1->set('mail', 'DL.WG.ET.WebPlatformsAcquia@exchange.asu.edu');
+    $user1->set('mail', 'DL.WG.ET.WebPlatforms@exchange.asu.edu');
     // Remove roles from the old user.
     $roles = $user1->getRoles();
     foreach ($roles as $role) {

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Services/ChangeSuperAdminService.php
@@ -83,6 +83,11 @@ class ChangeSuperAdminService {
     }
     // Reload the newUser object to get the new uid.
     $newUserReloaded = user_load_by_name($original_name);
+    $roles = $newUserReloaded->getRoles();
+    if (!in_array('administrator', $roles)) {
+      $newUserReloaded->addRole('administrator');
+      $newUserReloaded->save();
+    }
     $method = 'user_cancel_block_reassign_content_admin';
     $context = [
       'user_cancel_notify' => FALSE,

--- a/web/modules/asu_modules/asu_secure_superadmin/src/Services/EntityMassUpdateService.php
+++ b/web/modules/asu_modules/asu_secure_superadmin/src/Services/EntityMassUpdateService.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Drupal\asu_secure_superadmin\Services;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Link;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Renderer;
+use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\user\UserInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+/**
+ * Provides a service for updating multiple entities at once.
+ */
+class EntityMassUpdateService {
+  use DependencySerializationTrait;
+
+  /**
+   * Constructs a new EntityMassUpdateService object.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly ModuleExtensionList $moduleExtensionList,
+    private readonly MessengerInterface $messenger,
+    private readonly Renderer $renderer,
+    private readonly TranslationManager $translationManager,
+  ) {}
+
+  /**
+   * Updates all entities in the array with the passed-in field values.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID of the entities to update.
+   * @param \Drupal\user\UserInterface $account
+   *   The user account whose entities should be updated.
+   * @param array $updates
+   *   Array of key/value pairs with entity field names and the value to update
+   *   that field to.
+   * @param string $langcode
+   *   (optional) The language updates should be applied to. If none is
+   *   specified all available languages are processed.
+   * @param bool $load
+   *   (optional) TRUE if $entities contains an array of entity IDs to be
+   *   loaded, FALSE if it contains fully loaded entities. Defaults to FALSE.
+   * @param bool $revisions
+   *   (optional) TRUE if $entities contains an array of revision IDs instead
+   *   of entity IDs. Defaults to FALSE; will be ignored if $load is FALSE.
+   */
+  public function entityMassUpdate(string $entity_type_id, UserInterface $account, array $updates, $langcode = NULL, $load = FALSE, $revisions = FALSE) :void {
+    try {
+      $entities = $this->entityTypeManager->getStorage($entity_type_id)
+        ->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('uid', $account->id())
+        ->execute();
+    }
+    catch (InvalidPluginDefinitionException | PluginNotFoundException $e) {
+      $this->messenger->addWarning(t('No @type entities found for the user.', ['@type' => $entity_type_id]));
+      return;
+    }
+
+    // We use batch processing to prevent timeout when updating a large number
+    // of entities.
+    if (count($entities) > 10) {
+      $batch_builder = (new BatchBuilder())
+        ->addOperation([$this, 'entityMassUpdateBatchProcess'], [
+          $entity_type_id,
+          $entities,
+          $updates,
+          $langcode,
+          $load,
+          $revisions,
+        ])
+        ->setFinishCallback([$this, 'entityMassUpdateBatchFinished'])
+        ->setTitle(t('Processing'))
+        ->setErrorMessage(t('The update has encountered an error.'))
+        // We use a single multi-pass operation, so the default
+        // 'Remaining x of y operations' message will be confusing here.
+        ->setProgressMessage('');
+      batch_set($batch_builder->toArray());
+    }
+    else {
+      $storage = $this->entityTypeManager->getStorage($entity_type_id);
+      if ($entities) {
+        // Load the entities if no revisions.
+        if ($load && !$revisions) {
+          $entities = $storage->loadMultiple($entities);
+        }
+        // Update the entities.
+        foreach ($entities as $entity) {
+          // Load the entities if revisions.
+          if ($load && $revisions) {
+            $entity = $storage->loadRevision($entity);
+          }
+          assert($entity instanceof EntityInterface);
+          $this->entityMassUpdateHelper($entity, $updates, $langcode);
+        }
+      }
+      else {
+        $this->messenger->addWarning(t('No @type entities found for the user.', ['@type' => ucwords($entity_type_id)]));
+      }
+    }
+  }
+
+  /**
+   * Updates individual entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   A entity to update.
+   * @param array $updates
+   *   Associative array of updates.
+   * @param string $langcode
+   *   (optional) The language updates should be applied to. If none is
+   *   specified all available languages are processed.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   An updated entity object.
+   *
+   * @see entityMassUpdate()
+   */
+  public function entityMassUpdateHelper(EntityInterface $entity, array $updates, $langcode = NULL) :EntityInterface {
+    $langcodes = isset($langcode) ? [$langcode] : array_keys($entity->getTranslationLanguages());
+    // For efficiency manually save the original entity before applying changes.
+    $entity->original = clone $entity;
+    foreach ($langcodes as $langcode) {
+      foreach ($updates as $name => $value) {
+        $entity->getTranslation($langcode)->$name = $value;
+      }
+    }
+    $entity->save();
+    return $entity;
+  }
+
+  /**
+   * Implements callback_batch_operation().
+   *
+   * Executes a batch operation for entityMassUpdate().
+   *
+   * @param string $entity_type_id
+   *   The entity type ID of the entities to update.
+   * @param array $entities
+   *   An array of entity IDs.
+   * @param array $updates
+   *   Associative array of updates.
+   * @param string $langcode
+   *   The language updates should be applied to. If none is specified all
+   *   available languages are processed.
+   * @param bool $load
+   *   TRUE if $entities contains an array of entity IDs to be loaded, FALSE if
+   *   it contains fully loaded entities.
+   * @param bool $revisions
+   *   (optional) TRUE if $entities contains an array of revision IDs instead
+   *   of
+   *   entity IDs. Defaults to FALSE; will be ignored if $load is FALSE.
+   * @param array|\ArrayAccess $context
+   *   An array of contextual key/values.
+   */
+  public function entityMassUpdateBatchProcess(string $entity_type_id, array $entities, array $updates, $langcode, $load, $revisions, &$context) :void {
+    if (!isset($context['sandbox']['progress'])) {
+      $context['sandbox']['progress'] = 0;
+      $context['sandbox']['max'] = count($entities);
+      $context['sandbox']['entities'] = $entities;
+    }
+
+    // Process entities by groups of 5.
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
+    $count = min(5, count($context['sandbox']['entities']));
+    for ($i = 1; $i <= $count; $i++) {
+      // Load each entity, reset the values, and save it.
+      $entity = array_shift($context['sandbox']['entities']);
+      if ($load) {
+        $entity = $revisions ?
+          $storage->loadRevision($entity) : $storage->load($entity);
+      }
+      if ($entity) {
+        $entity = $this->entityMassUpdateHelper($entity, $updates, $langcode);
+        // Store result for post-processing in the finished callback.
+        $context['results'][] = Link::fromTextAndUrl($entity->label(), $entity->toUrl())
+          ->toString();
+      }
+
+      // Update our progress information.
+      $context['sandbox']['progress']++;
+    }
+
+    // Inform the batch engine that we are not finished,
+    // and provide an estimation of the completion level we reached.
+    if ($context['sandbox']['progress'] != $context['sandbox']['max']) {
+      $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+    }
+  }
+
+  /**
+   * Implements callback_batch_finished().
+   *
+   * Reports the 'finished' status of batch operation for entityMassUpdate().
+   *
+   * @param bool $success
+   *   A boolean indicating whether the batch mass update operation
+   *   successfully
+   *   concluded.
+   * @param string[] $results
+   *   An array of rendered links to entities updated via the batch mode
+   *   process.
+   * @param array $operations
+   *   An array of function calls (not used in this function).
+   *
+   * @see entityMassUpdateBatchProcess()
+   */
+  public function entityMassUpdateBatchFinished($success, array $results, array $operations) :void {
+    if ($success) {
+      $this->messenger->addStatus(t('The update has been performed.'));
+    }
+    else {
+      $this->messenger
+        ->addError(t('An error occurred and processing did not complete.'));
+      $message = $this->translationManager
+        ->formatPlural(count($results), '1 item successfully processed:', '@count items successfully processed:');
+      $item_list = [
+        '#theme' => 'item_list',
+        '#items' => $results,
+      ];
+      $message .= $this->renderer->render($item_list);
+      $this->messenger->addStatus($message);
+    }
+  }
+
+}

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -5,7 +5,6 @@
  * Install, update and uninstall functions for the Webspark installation profile.
  */
 
-use Drupal\user\Entity\User;
 use Drupal\user\Entity\Role;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\pathauto\PathautoGeneratorInterface;
@@ -26,11 +25,6 @@ function webspark_install() {
     ->getEditable('system.theme')
     ->set('default', 'renovation')
     ->save();
-
-  // Assign user 1 the "administrator" role.
-  $user = User::load(1);
-  $user->roles[] = 'administrator';
-  $user->save();
 
   // Enable webspark_installer module.
   \Drupal::service('module_installer')

--- a/web/profiles/webspark/webspark/webspark.profile
+++ b/web/profiles/webspark/webspark/webspark.profile
@@ -38,23 +38,6 @@ function webspark_install_tasks(&$install_state) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter() for install_configure_form().
- *
- * Allows the profile to alter the site configuration form.
- */
-function webspark_form_install_configure_form_alter(&$form, FormStateInterface $form_state): void {
-  $form['admin_account']['openasu_admin_asurite'] = [
-    '#title' => 'ASURITE User ID',
-    '#description' => t('Associate admin account with ASURITE User'),
-    '#type' => 'textfield',
-    '#required' => FALSE,
-    '#weight' => 20,
-  ];
-  $form['regional_settings']['site_default_country']['#default_value'] = 'US';
-  $form['#submit'][] = 'webspark_form_install_configure_submit';
-}
-
-/**
  * Submission handler to sync the contact.form.feedback recipient.
  */
 function webspark_form_install_configure_submit($form, FormStateInterface $form_state): void {
@@ -63,14 +46,6 @@ function webspark_form_install_configure_submit($form, FormStateInterface $form_
   $block = $config_factory->getEditable('block.block.asubrandheader');
   $block->set('settings.asu_brand_header_block_title', $form_state->getValue('site_name'));
   $block->save(TRUE);
-
-  // If the ASURITE User ID is populated during installation
-  // then the CAS Username from the account of the admin user will be stored.
-  if(!empty($form_state->getValue('openasu_admin_asurite'))) {
-    $user = User::load(1);
-    $cas_user_manager = \Drupal::service('cas.user_manager');
-    $cas_user_manager->setCasUsernameForAccount($user, $form_state->getValue('openasu_admin_asurite'));
-  }
 }
 
 /**


### PR DESCRIPTION
### Description
Note:
- This module adds itself to the monorepo workflow so that it gets synced with a corresponding git repo and packagist package, which have already been set up.
- It also adds and relies entirely on a pretty substantial patch in Drupal core which may or may not ever get adopted. So, we will need to remove this module at some future date. It's kind of a one-off, anyway.

QA Steps:
- Integrated composer should have installed the patch without problems.
- Log in and enable the ASU Secure Superadmin module. You should see a message to go to the configuration page. Click on it.
- When on the configuration page, click on the button to secure the superadmin account.
- This will kick off a process that will disable the user1 user and reparent its contents into a new user. It changes uid=1 to be named "etsuper." You can check if this is the case by going to `/admin/people` and looking to see if the "admin" account now has a uid of 35 and if "etsuper" has a uid of 1.
- The roles should have been removed from etsuper, and it should be blocked. Check if this is the case on this page.
- All of the content associated with uid1 should now be associated with uid35. So, if you go to `/admin/content`, you should see a lot of nodes that were updated recently and they should be owned by the "admin" user. If you click on the hyperlink for "admin" and when its profile page comes up, hover over "Edit." This should show you that the uid is 35. If so, this worked.
- Go back to `/admin/content` and click on the Media tab. You should see a similar thing, where several media items have been updated to be owned by "admin," which now has a uid of 35.
- Another thing to test would be to test a new site spinup locally. This should have no problems on a new Webspark spinup.
- A final test would be to test this module in a vanilla, non-webspark site.


### Links

- [JIRA ticket](https://asudev.jira.com/browse/ACMN-52)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

