### PR TITLE
WS2-2298: Removed title from form label

### DIFF
--- a/web/themes/webspark/renovation/templates/form/form-element-label.html.twig
+++ b/web/themes/webspark/renovation/templates/form/form-element-label.html.twig
@@ -24,7 +24,7 @@
 {% if title is not empty or required -%}
   <label{{ attributes.addClass(classes) }}>
     {% if required %}
-      <span title="Required" class="fa fa-icon fa-circle uds-field-required"></span>
+      <span class="fa fa-icon fa-circle uds-field-required"></span>
     {% endif %}
     {{ title }}
   </label>


### PR DESCRIPTION
### Description

<!-- Description of problem -->
#### Solution
Removed the `title` attribute from the `span` that marks required fields in the form label Twig template.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2298)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
