### PR TITLE
Acmn 202

### DIFF
--- a/web/modules/asu_modules/asu_brand/js/asu_brand.header.js
+++ b/web/modules/asu_modules/asu_brand/js/asu_brand.header.js
@@ -25,6 +25,14 @@
   // Get config values passed in from AsuBrandHeaderBlock.php
   var props = drupalSettings.asu_brand.props;
 
+  // ACMN-202 Obtain current site domain, if not explictly defined.
+  if (!props.site) {
+    props.site = window.location.host;
+  }
+  if (props.site === 'opt-out') {
+    delete props.site;
+  }
+
   // Pantheon strips some cookie values before they hit PHP, so
   // Attempt to get userName prop in JS here for those instances.
   var name = 'SSONAME=';

--- a/web/modules/asu_modules/asu_brand/src/AsuBrandHelperFunctions.php
+++ b/web/modules/asu_modules/asu_brand/src/AsuBrandHelperFunctions.php
@@ -15,10 +15,9 @@ class AsuBrandHelperFunctions {
     $search_config = \Drupal::config('asu_brand.settings');
     $asu_search_url = $search_config->get('asu_brand.asu_brand_search_url') ?? '';
     // Domain-specific results host
-    $local_search_url = !empty($search_config->get('asu_brand.asu_brand_local_search_url')) ? $search_config->get('asu_brand.asu_brand_local_search_url') : \Drupal::request()->getHost();
-    // Check for "opt-out" override.
-    $url_host = ($local_search_url === 'opt-out') ? '' : $local_search_url;
-    return ['asu_search_url' => $asu_search_url, 'url_host' => $url_host];
+    $local_search_url = !empty($search_config->get('asu_brand.asu_brand_local_search_url')) ? $search_config->get('asu_brand.asu_brand_local_search_url') : '';
+    // Check for "opt-out" override is now handled in frontend js.
+    return ['asu_search_url' => $asu_search_url, 'url_host' => $local_search_url];
   }
 
   /**


### PR DESCRIPTION
### Description

To keep us in sync with Acquia repos...

Addresses ACMN-202
In Site Factory `\Drupal::request()->getHost();` behaves differently than on our old host and it is returning the `[sitename].acsitefactory.com` host instead of the currently active host visible in the browser. This update shifts the logic that is used when no explicit host is provided so it is obtained on the frontend, in the browser and will match the current active domain.

To verify:

Case 1

Ensure the "Local Search URL" field is empty at `/admin/config/asu_brand/settings`. Clear the cache if changes are made.
Visit the front page of the site. The search form in the header should have the following tag: `<input name="url_host" type="hidden" value="yoursite.acquia.asu.edu">` where `yoursite.acquia.asu.edu` is the current site's domain.

Case 2

Add a domain such as tech.asu.edu to  the Local Search URL at `/admin/config/asu_brand/settings`. Clear the cache.
Visit the front page of the site. The search form in the header should now have the following tag: `<input name="url_host" type="hidden" value="tech.asu.edu">`.

Case 3

Add the value opt-out to  the Local Search URL at `/admin/config/asu_brand/settings`. Clear the cache.
Visit the front page of the site. The search form in the header should now have the following tag: `<input name="url_host" type="hidden" value="">`.

Default in most sites is Case 1

For reference, PR for Acquia WS2 D10 stack: https://code.acquia.com/ArizonaBoardofRegentsSiteFactoryACSFSites/asufactory1/-/merge_requests/77


### Links

- [JIRA ticket](https://asudev.jira.com/browse/ACMN-202)
