### PR TITLE
[DRAFT] WS2-2431: Anchor Menu: mobile view & zoomed-in desktop view redirect to wrong anchored position

### DIFF
--- a/web/modules/webspark/webspark_blocks/js/anchor-menu.js
+++ b/web/modules/webspark/webspark_blocks/js/anchor-menu.js
@@ -161,7 +161,6 @@
     // Set click event of anchors
     for (let [anchor, anchorTarget] of anchorTargets) {
       anchor.addEventListener('click', function (e) {
-        e.preventDefault();
 
         // Compensate for height of navbar so content appears below it
         let scrollBy =
@@ -194,6 +193,12 @@
         }
 
         e.target.classList.add('active');
+
+        $('#collapseExample').removeClass('show');
+        const h2Element = document.querySelector('h2[data-bs-target="#collapseExample"]');
+        if (h2Element) {
+          h2Element.ariaExpanded = false;
+        }
       });
     }
   }


### PR DESCRIPTION


### Description
Added close functionality when clicking an anchor in the Anchor menu and removed preventDefault.
<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2431)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
