### PR TITLE
WS2-2613: Removed aria-labelledby on div

### DIFF
--- a/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
+++ b/web/themes/webspark/renovation/templates/block/asu-footer--footer-block.html.twig
@@ -152,9 +152,7 @@
             </div>
             <div
               id="footlink-{{ key }}-{{ loop.index }}"
-              class="collapse accordion-body"
-              aria-labelledby="footlink-header-{{ key }}-{{ loop.index }}"
-            >
+              class="collapse accordion-body">
               {# WS2-1268: Adding block title to data-ga-footer-component attribute.
                Building menu items here to access block title, rather than in AsuFooterBlock.php
                TODO: Rewrite this module as UDS react components similar to the ASU Header


### PR DESCRIPTION
### Description
Here’s the report on our portal - [Siteimprove](https://my2.us.siteimprove.com/Accessibility/1032743/NextGen/Issue/1?conformance=&siteTargetIssueKinds=1,2&wcagVersion=21&pageSegments=&ruleName=sia-r18&ruleId=18&issueKind=1&exceptTags=1,2&siteTarget.wcagVersion=21&siteTarget.conformanceLevels=0,1,2,3,4&siteTarget.issueKinds=1,2)
Removed aria-labelledby on div
<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2613)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
