### PR TITLE
[HOLD] WS2-2381: Image Background with Call to Action: heading text is missing semantic element header tag

### DIFF
--- a/web/themes/webspark/renovation/src/components/image-background-with-cta/image-background-with-cta.twig
+++ b/web/themes/webspark/renovation/src/components/image-background-with-cta/image-background-with-cta.twig
@@ -18,7 +18,7 @@
   class="uds-image-background-with-cta"
   style="background-image: linear-gradient(rgba(25, 25, 25, 0) 0%, rgba(25, 25, 25, 0.79) 100%), url('{{ image }}');">
   <div class="uds-image-background-with-cta-container uds-content-align">
-    <span>{{ heading }}</span>
+    <span><h2>{{ heading }}</h2></span>
     {{ cta_btn }}
   </div>
 </section>


### PR DESCRIPTION
### Description
Added h2 tag inside uds-image-background-with-cta-container
<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2381)

### Checklist

- [ ] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [ ] Solution is documented on the Jira ticket
- [ ] QA steps to verify have been included on the Jira ticket
- [ ] No new PHP or JS errors
- [ ] No accessibility issues are introduced with this update
- [ ] Added/updated README.md files, if relevant
- [ ] Confirm that any yaml files included have a matching update hook

### Verified in browsers 

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Screenshots

<!-- Provide screenshots -->

Note: Sections that are not applicable for this issue can be removed.
